### PR TITLE
Don't add the kernel modules to the kernel-base package. This breaks the kernel-modules metapackage which is automatically created.

### DIFF
--- a/recipes-kernel/linux/linux-xlnx.inc
+++ b/recipes-kernel/linux/linux-xlnx.inc
@@ -29,9 +29,6 @@ COMPATIBLE_MACHINE = "qemumicroblaze|qemuzynq|microblaze|zynq"
 MACHINE_KCONFIG_append_zynq += "common/zynq_defconfig_${LINUX_VERSION}.cfg"
 MACHINE_KCONFIG_append_microblaze += "common/microblaze_defconfig_${LINUX_VERSION}.cfg"
 
-# Add the modules directory to the 'kernel-base' files list
-FILES_kernel-base_append = " /lib/modules/${KERNEL_VERSION}/kernel"
-
 # returns all the elements from the src uri that are .cfg files
 def find_config_fragments(d):
     sources=src_patches(d, True)


### PR DESCRIPTION
Don't add the kernel modules to the kernel-base package. This breaks the kernel-modules metapackage which is automatically created.

By adding the kernel module files to the kernel-base package, the kernel-modules metapackage breaks. The metapackage depends on automatically created kernel-module packages (named kernel-module-<modulename>) which are empty if the files are added to the kernel-base package. This causes bitbake to not create the packages for installing later as they wouldn't have any effect anyway. The twist is, that the kernel-modules metapackage depends on these packages. During creation of the rootfs, the process fails, because those packages can't be found.

If modules should be installed in the image, don't use the kernel-base package for that. The kernel-modules package is the right one.
