### PR TITLE
to me this looks like the correct checksum for the 2015.2 tag

### DIFF
--- a/recipes-kernel/linux/linux-xlnx_3.19.bb
+++ b/recipes-kernel/linux/linux-xlnx_3.19.bb
@@ -1,6 +1,6 @@
 LINUX_VERSION = "3.19"
 KBRANCH ?= "master"
-SRCREV ?= "dda52ddca3e375d949a669177d6f5063cdcf713e"
+SRCREV ?= "3f30b3337af61f1ed98f7185e37c6bf9202b3204"
 
 include linux-xlnx.inc
 


### PR DESCRIPTION
I had problems with the xylon driver with the linux-xlnx_3.19.bb recipe. So, I took a look at the checksum and it didn't match what's here
https://github.com/Xilinx/linux-xlnx/tree/xilinx-v2015.2

This one seems to be what is there now at least for the 2015.2 tag.
