### PR TITLE
zynq7-base.dtsi: Correct default ps7-spi chip select configuration

### DIFF
--- a/recipes-bsp/device-tree/files/common/zynq7-base.dtsi
+++ b/recipes-bsp/device-tree/files/common/zynq7-base.dtsi
@@ -346,7 +346,8 @@
 			compatible = "xlnx,zynq-spi-r1p6", "xlnx,ps7-spi-1.00.a";
 			interrupt-parent = <&ps7_scugic_0>;
 			interrupts = <0 26 4>;
-			num-chip-select = <4>;
+			num-cs = <3>;
+			is-decoded-cs = <0>;
 			reg = <0xe0006000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -357,7 +358,8 @@
 			compatible = "xlnx,zynq-spi-r1p6", "xlnx,ps7-spi-1.00.a";
 			interrupt-parent = <&ps7_scugic_0>;
 			interrupts = <0 49 4>;
-			num-chip-select = <4>;
+			num-cs = <3>;
+			is-decoded-cs = <0>;
 			reg = <0xe0007000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
Per kernel docs (Documentation/devicetree/bindings/spi/spi-{bus,cadence}.txt)
and source (drivers/spi/spi-cadence.c), 'num-cs' rather than 'num-chip-select'
is the correct name for the device tree node describing the number of
chipselects available.  Further, the Zynq PS has 3 chip select lines not 4,
so update the default number to 3.  And to avoid ambiguity, specify that
by default (unless the user adds logic in the PL or off-chip) they are direct,
not 3-to-8 decoded.

Signed-off-by: Henry Hallam henry@pericynthion.org
