### PR TITLE
Corrected file format

### DIFF
--- a/meta-xilinx-bsp/conf/machine/picozed-zynq7.conf
+++ b/meta-xilinx-bsp/conf/machine/picozed-zynq7.conf
@@ -9,7 +9,7 @@
 SOC_VARIANT ?= "7z"
 
 require conf/machine/include/tune-zynq.inc
-conf/machine/include/machine-xilinx-overrides.inc
+require conf/machine/include/machine-xilinx-overrides.inc
 require conf/machine/include/machine-xilinx-default.inc
 require conf/machine/include/machine-xilinx-board.inc
 


### PR DESCRIPTION
The `require` was missing on this line making it fail parsing.  Note: this does not fix the ability to build a bootable picozed image, only that the parse will work.