### PR TITLE
fix two bugs building libmali-xlnx on zynqmp

### DIFF
--- a/meta-xilinx-bsp/recipes-graphics/libgles/libmali-xlnx.bb
+++ b/meta-xilinx-bsp/recipes-graphics/libgles/libmali-xlnx.bb
@@ -17,11 +17,11 @@ FILESEXTRAPATHS_append := " \
 
 
 # Fetch the MALI 400 binaries from here
-# https://www.xilinx.com/member/forms/download/mali-driver-license.html?filename=mali-400-userspace.tar
+# https://www.xilinx.com/publications/products/tools/mali-400-userspace.tar
 
 PV = "r8p0-01rel0"
 SRC_URI = " \
-    https://www.xilinx.com/member/forms/download/mali-driver-license.html?filename=mali-400-userspace.tar;downloadfilename=mali-400-userspace.tar \
+    https://www.xilinx.com/publications/products/tools/mali-400-userspace.tar \
     file://egl.pc \
     file://glesv1_cm.pc \
     file://glesv1.pc \

--- a/meta-xilinx-bsp/recipes-graphics/libgles/libmali-xlnx.bb
+++ b/meta-xilinx-bsp/recipes-graphics/libgles/libmali-xlnx.bb
@@ -116,6 +116,12 @@ do_install() {
     fi
 }
 
+do_install_append () {
+    # libwayland-egl has been moved to wayland 1.15+
+    rm -f ${D}${libdir}/libwayland-egl*
+    rm -f ${D}${libdir}/pkgconfig/wayland-egl.pc
+    rmdir --ignore-fail-on-non-empty ${D}${libdir}/pkgconfig
+}
 
 # Inhibit warnings about files being stripped
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"


### PR DESCRIPTION
bug was triggered by compiling a Yocto image with OpenCV.

IMAGE_INSTALL_append += "opencv"