### PR TITLE
ZCU102 and ZCU111 default build support

### DIFF
--- a/meta-xilinx-bsp/conf/machine/zcu102-zynqmp.conf
+++ b/meta-xilinx-bsp/conf/machine/zcu102-zynqmp.conf
@@ -29,6 +29,7 @@ KERNEL_DEVICETREE = "xilinx/zynqmp-zcu102-rev1.0.dtb"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-xlnx"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-xlnx"
 PREFERRED_PROVIDER_virtual/pmu-firmware ?= "zynqmp-pmu-pmu-firmware"
+PREFERRED_PROVIDER_virtual/boot-bin ?= "xilinx-bootbin"
 
 EXTRA_IMAGEDEPENDS += " \
 		u-boot-zynq-uenv \
@@ -38,7 +39,7 @@ EXTRA_IMAGEDEPENDS += " \
 		virtual/boot-bin \
 		"
 
-IMAGE_BOOT_FILES += "uEnv.txt atf-uboot.ub ${KERNEL_IMAGETYPE}-zynqmp-zcu102-rev1.0.dtb"
+IMAGE_BOOT_FILES += "boot.bin uEnv.txt atf-uboot.ub ${KERNEL_IMAGETYPE}-zynqmp-zcu102-rev1.0.dtb"
 
 # This machine has a QEMU model, runqemu setup:
 IMAGE_CLASSES += "qemuboot-xilinx"

--- a/meta-xilinx-bsp/conf/machine/zcu106-zynqmp.conf
+++ b/meta-xilinx-bsp/conf/machine/zcu106-zynqmp.conf
@@ -22,6 +22,7 @@ KERNEL_DEVICETREE = "xilinx/zynqmp-zcu106-revA.dtb"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-xlnx"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-xlnx"
 PREFERRED_PROVIDER_virtual/pmu-firmware ?= "zynqmp-pmu-pmu-firmware"
+PREFERRED_PROVIDER_virtual/boot-bin ?= "xilinx-bootbin"
 
 EXTRA_IMAGEDEPENDS += " \
 		u-boot-zynq-uenv \
@@ -30,6 +31,6 @@ EXTRA_IMAGEDEPENDS += " \
 		virtual/boot-bin \
 		"
 
-IMAGE_BOOT_FILES += "uEnv.txt atf-uboot.ub ${KERNEL_IMAGETYPE}-zynqmp-zcu106-revA.dtb"
+IMAGE_BOOT_FILES += "boot.bin uEnv.txt atf-uboot.ub ${KERNEL_IMAGETYPE}-zynqmp-zcu106-revA.dtb"
 
 MACHINE_HWCODECS = "libomxil-xlnx"

--- a/meta-xilinx-bsp/conf/machine/zcu111-zynqmp.conf
+++ b/meta-xilinx-bsp/conf/machine/zcu111-zynqmp.conf
@@ -24,6 +24,7 @@ KERNEL_DEVICETREE = "xilinx/zynqmp-zcu111-revA.dtb"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-xlnx"
 PREFERRED_PROVIDER_virtual/bootloader ?= "u-boot-xlnx"
 PREFERRED_PROVIDER_virtual/pmu-firmware ?= "zynqmp-pmu-pmu-firmware"
+PREFERRED_PROVIDER_virtual/boot-bin ?= "xilinx-bootbin"
 
 EXTRA_IMAGEDEPENDS += " \
 		u-boot-zynq-uenv \
@@ -31,4 +32,4 @@ EXTRA_IMAGEDEPENDS += " \
 		virtual/pmu-firmware \
 		virtual/boot-bin \
 		"
-IMAGE_BOOT_FILES += "uEnv.txt atf-uboot.ub ${KERNEL_IMAGETYPE}-zynqmp-zcu111-revA.dtb"
+IMAGE_BOOT_FILES += "boot.bin uEnv.txt atf-uboot.ub ${KERNEL_IMAGETYPE}-zynqmp-zcu111-revA.dtb"

--- a/meta-xilinx-bsp/recipes-bsp/pmu-firmware/pmu-firmware_2017.3.bb
+++ b/meta-xilinx-bsp/recipes-bsp/pmu-firmware/pmu-firmware_2017.3.bb
@@ -19,12 +19,12 @@ append_target_provides[eventmask] = "bb.event.RecipeParsed"
 # itself is licensed under a modified MIT license which restricts use to Xilinx
 # devices only.
 LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://../../../../license.txt;md5=530190e8d7ebcdfeddbe396f3f20417f"
+LIC_FILES_CHKSUM = "file://../../../../license.txt;md5=2a8d7a7f870f65ce77e8ccd8150cce10"
 
 inherit deploy
 
-XILINX_RELEASE_VERSION = "v2017.3"
-SRCREV = "3c9f0cfde9307c2dc1a298f9f22d492601232821"
+XILINX_RELEASE_VERSION = "v2018.2"
+SRCREV = "a99703bd31159fd3fae2c480cbdd4d9157cd68ca"
 PV = "${XILINX_RELEASE_VERSION}+git${SRCPV}"
 
 SRC_URI = "git://github.com/Xilinx/embeddedsw.git;protocol=https;nobranch=1"


### PR DESCRIPTION
The first patch is to bring the PMU firmware release up to match the version of the layer.  Prior to meta-xilinx being reorganized into 2 layers, the version was set to 2018.1.  Then the reorg was pushed and that was removed for 2017.3, which hangs if using the meta-xilinx-tools FSBL.  

The second patch enforces the preferred provider to be the meta-xilinx-tools xilinx-bootbin (FSBL) since it's not being picked up/inferred otherwise (error is No provider for virtual/boot-bin).  Because this is a Xilinx release -named branch vs. Yocto, it makes sense that the default preferred provider might be meta-xilinx-tools' option given the U-Boot SPL doesn't work without additional patch(es) (also noted on the meta-xilinx mailing list, several times).  As part of that enforcement, we also make the boot.bin a image dependency.