### PR TITLE
linux-firmware: Fix typos in the recipe.

### DIFF
--- a/meta-xilinx-contrib/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/meta-xilinx-contrib/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -29,13 +29,13 @@ FILES_${PN}-mfgtest_minized-zynq7 = " \
 "
 
 FILES_${PN}-bcm43430_append_minized-zynq7 = " \
-       ${nonarch_base_libdir}/firmware/brcm/ brcmfmac43430-sdio.txt \
+       ${nonarch_base_libdir}/firmware/brcm/brcmfmac43430-sdio.txt \
 "
 
 LICENSE_${PN}-bcm43430a1-hcd = "Firmware-cypress"
 
 FILES_${PN}-bcm43430a1-hcd = " \
-  ${nonarch_base_libdir}/firmware/brcm/BCM43430A1.1DX.hcd \
+  ${nonarch_base_libdir}/firmware/brcm/CYW43430A1.1DX.hcd \
 "
 
 RDEPENDS_${PN}-bcm43430a1-hcd += "${PN}-cypress-license"


### PR DESCRIPTION
 * Packaged wrong file name.
 * Space in FILES caused all bcrm firmware to end up in the added package.