### PR TITLE
ZynqMP+: Use a proper SD device in U-Boot scripts (uEnv, scr).

### DIFF
--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx/v2019.1/0001-arm64-zynqmp-fix-preprocessor-check-for-SPL_ZYNQMP_T.patch
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx/v2019.1/0001-arm64-zynqmp-fix-preprocessor-check-for-SPL_ZYNQMP_T.patch
@@ -1,0 +1,34 @@
+From 6b6f167a3dfda679c520d9e34da99de779296c82 Mon Sep 17 00:00:00 2001
+From: Luca Ceresoli <luca@lucaceresoli.net>
+Date: Mon, 15 Apr 2019 16:18:18 +0200
+Subject: [PATCH] arm64: zynqmp: fix preprocessor check for
+ SPL_ZYNQMP_TWO_SDHCI
+
+A missing CONFIG_ prefix while checking for this Kconfig variable makes the
+check always fail. Fix it. While there also switch from the '#if defined'
+form to the '#ifdef' form as the other checks in this function.
+
+Fixes: 35e2b92344b1 ("arm64: zynqmp: Fix logic around CONFIG_ZYNQ_SDHCI")
+
+Signed-off-by: Luca Ceresoli <luca@lucaceresoli.net>
+Signed-off-by: Michal Simek <michal.simek@xilinx.com>
+---
+ arch/arm/mach-zynqmp/spl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/mach-zynqmp/spl.c b/arch/arm/mach-zynqmp/spl.c
+index 57d65abfc7..bcc770606b 100644
+--- a/arch/arm/mach-zynqmp/spl.c
++++ b/arch/arm/mach-zynqmp/spl.c
+@@ -85,7 +85,7 @@ u32 spl_boot_device(void)
+ 	case SD_MODE1:
+ 	case SD1_LSHFT_MODE: /* not working on silicon v1 */
+ /* if both controllers enabled, then these two are the second controller */
+-#if defined(SPL_ZYNQMP_TWO_SDHCI)
++#ifdef CONFIG_SPL_ZYNQMP_TWO_SDHCI
+ 		return BOOT_DEVICE_MMC2;
+ /* else, fall through, the one SDHCI controller that is enabled is number 1 */
+ #endif
+-- 
+2.24.0
+

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx/v2019.1/0003-arm64-zynqmp-configs-Fix-sdbootdev-environment-varia.patch
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx/v2019.1/0003-arm64-zynqmp-configs-Fix-sdbootdev-environment-varia.patch
@@ -1,0 +1,44 @@
+From a3f54a40aefebccff66e653086407af6c593007d Mon Sep 17 00:00:00 2001
+From: Adrian Fiergolski <adrian.fiergolski@fastree3d.com>
+Date: Fri, 15 Nov 2019 15:10:28 +0100
+Subject: [PATCH] arm64: zynqmp: configs: Fix sdbootdev environment variable in
+ case two SDHCI controllers are used.
+
+With this patch, sdbootdev variable points to the right SDHCI
+controller, such the commands defined in
+CONFIG_EXTRA_ENV_BOARD_SETTINGS work properly also in case of
+a ZynqMP+ SoC with two controllers.
+
+Signed-off-by: Adrian Fiergolski <adrian.fiergolski@fastree3d.com>
+---
+ include/configs/xilinx_zynqmp.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/include/configs/xilinx_zynqmp.h b/include/configs/xilinx_zynqmp.h
+index 8e600f3019..df0f03dd27 100644
+--- a/include/configs/xilinx_zynqmp.h
++++ b/include/configs/xilinx_zynqmp.h
+@@ -104,6 +104,14 @@
+ 
+ /* Xilinx initial environment variables */
+ #ifndef CONFIG_EXTRA_ENV_BOARD_SETTINGS
++
++/* if both controllers enabled, then these two are the second controller */
++#if defined(CONFIG_SPL_ZYNQMP_TWO_SDHCI)
++# define SDBOOTDEV "sdbootdev=1\0"
++#else
++# define SDBOOTDEV "sdbootdev=0\0"
++#endif
++
+ #define CONFIG_EXTRA_ENV_BOARD_SETTINGS \
+ 	"kernel_addr=0x80000\0" \
+ 	"initrd_addr=0xa00000\0" \
+@@ -111,7 +119,7 @@
+ 	"fdt_addr=4000000\0" \
+ 	"fdt_high=0x10000000\0" \
+ 	"loadbootenv_addr=0x100000\0" \
+-	"sdbootdev=0\0"\
++	SDBOOTDEV \
+ 	"kernel_offset=0x280000\0" \
+ 	"fdt_offset=0x200000\0" \
+ 	"kernel_size=0x1e00000\0" \

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx_2019.1.bb
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx_2019.1.bb
@@ -10,6 +10,8 @@ include u-boot-spl-zynq-init.inc
 
 SRC_URI_append_kc705-microblazeel = " file://microblaze-kc705-Convert-microblaze-generic-to-k.patch"
 
+SRC_URI += "file://0003-arm64-zynqmp-configs-Fix-sdbootdev-environment-varia.patch" 
+
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://README;beginline=1;endline=4;md5=744e7e3bb0c94b4b9f6b3db3bf893897"
 

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx_2019.1.bb
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx_2019.1.bb
@@ -10,7 +10,9 @@ include u-boot-spl-zynq-init.inc
 
 SRC_URI_append_kc705-microblazeel = " file://microblaze-kc705-Convert-microblaze-generic-to-k.patch"
 
-SRC_URI += "file://0003-arm64-zynqmp-configs-Fix-sdbootdev-environment-varia.patch" 
+SRC_URI += "file://0003-arm64-zynqmp-configs-Fix-sdbootdev-environment-varia.patch \ 
+            file://0001-arm64-zynqmp-fix-preprocessor-check-for-SPL_ZYNQMP_T.patch \
+	   " 
 
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://README;beginline=1;endline=4;md5=744e7e3bb0c94b4b9f6b3db3bf893897"

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd
@@ -1,6 +1,6 @@
-setenv bootargs $bootargs root=/dev/mmcblk0p2 rw rootwait earlycon clk_ignore_unused
+setenv bootargs $bootargs root=/dev/mmcblk${sdbootdev}p2 rw rootwait earlycon clk_ignore_unused
 devicetree_image=@@DEVICE_TREE_NAME@@
-fatload mmc 0 ${fdt_addr_r} ${devicetree_image}
+fatload mmc $sdbootdev ${fdt_addr_r} ${devicetree_image}
 fatload mmc $sdbootdev:$partid  ${kernel_addr_r} @@KERNEL_IMAGETYPE@@
 booti ${kernel_addr_r} - ${fdt_addr_r}
 

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd.zynqmp
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd.zynqmp
@@ -1,4 +1,4 @@
-setenv bootargs $bootargs root=/dev/mmcblk0p2 rw rootwait earlycon clk_ignore_unused
-fatload mmc 0 @@DEVICETREE_ADDRESS@@ @@DEVICE_TREE_NAME@@
+setenv bootargs $bootargs root=/dev/mmcblk${sdbootdev}p2 rw rootwait earlycon clk_ignore_unused
+fatload mmc $sdbootdev @@DEVICETREE_ADDRESS@@ @@DEVICE_TREE_NAME@@
 fatload mmc $sdbootdev:$partid @@KERNEL_LOAD_ADDRESS@@ @@KERNEL_IMAGETYPE@@
 @@KERNEL_BOOTCMD@@ @@KERNEL_LOAD_ADDRESS@@ - @@DEVICETREE_ADDRESS@@


### PR DESCRIPTION
It fixes the u-boot scripts in case a ZynqMP+ SoC comes with two SDHCI controllers.
It requires a proper enumeration in the U-Boot Device tree, i.e.
 mmc0 = &sdhci0;
 mmc1 = &sdhci1;
not
 mmc0 = &sdhci1;
 mmc1 = &sdhci0;
The second enumeration being a workaround (always boot from mmc0),
is not required anymore as u-boot for ZynqMP+ defines 'sdbootdev'
environment variable. Moreover, the proper enumeration allows to
select proper block device (mmcblk0p2 vs mmcblk1p2) passed as 'root'
parameter to kernel.

Signed-off-by: Adrian Fiergolski <adrian.fiergolski@fastree3d.com>