### PR TITLE
Fix CONFIG_PMUFW_INIT_FILE extension.

### DIFF
--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-spl-zynq-init.inc
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-spl-zynq-init.inc
@@ -64,9 +64,7 @@ python () {
         d.setVar("SPL_BINARY", "")
 
     if providesbin and d.getVar("SOC_FAMILY") in ["zynqmp"]:
-        # determine the path relative to the source tree
-        relpath = os.path.relpath(d.expand("${PMU_FIRMWARE_DEPLOY_DIR}/${PMU_FIRMWARE_IMAGE_NAME}.bin"), d.getVar("S"))
         # setup PMU Firmware path via MAKEFLAGS
-        d.appendVar("EXTRA_OEMAKE", " CONFIG_PMUFW_INIT_FILE=\"{0}\"".format(relpath))
+        d.appendVar("EXTRA_OEMAKE", " CONFIG_PMUFW_INIT_FILE=\"{0}\"".format("${PMU_FIRMWARE_DEPLOY_DIR}/${PMU_FIRMWARE_IMAGE_NAME}.bin"))
 }
 


### PR DESCRIPTION
The solution with the relative path doesn't work if devtool is involved:
getVar returns value of S variable before it gets overwritten by devtool recipe
which cause compilation failure.
The solution is to use absolute path to the pmu firmware.

Signed-off-by: Adrian Fiergolski <adrian.fiergolski@fastree3d.com>