### PR TITLE
ZynqMP+: Use a proper SD device in U-Boot scripts (uEnv, scr).

### DIFF
--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr.bb
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr.bb
@@ -50,6 +50,8 @@ KERNEL_LOAD_ADDRESS_versal ?= "0x80000"
 RAMDISK_IMAGE_ADDRESS_zynq ?= "0x4000000"
 RAMDISK_IMAGE_ADDRESS_versal ?= "0x6000000"
 
+SDBOOTDEV ?= "0"
+
 do_configure[noexec] = "1"
 do_install[noexec] = "1"
 
@@ -61,6 +63,7 @@ do_compile() {
         -e 's/@@RAMDISK_IMAGE@@/${RAMDISK_IMAGE}/' \
         -e 's/@@RAMDISK_IMAGE_ADDRESS@@/${RAMDISK_IMAGE_ADDRESS}/' \
         -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
+        -e 's/@@SDBOOTDEV@@/${SDBOOTDEV}/' \	
         "${WORKDIR}/boot.cmd.${BOOTMODE}.${SOC_FAMILY}" > "${WORKDIR}/boot.cmd"
     mkimage -A arm -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
     sed -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd.zynqmp
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd.zynqmp
@@ -1,3 +1,4 @@
+setenv sdbootdev @@SDBOOTDEV@@
 setenv bootargs $bootargs root=/dev/mmcblk${sdbootdev}p2 rw rootwait earlycon clk_ignore_unused
 fatload mmc $sdbootdev @@DEVICETREE_ADDRESS@@ @@DEVICE_TREE_NAME@@
 fatload mmc $sdbootdev:$partid @@KERNEL_LOAD_ADDRESS@@ @@KERNEL_IMAGETYPE@@

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd.zynqmp
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd.zynqmp
@@ -1,4 +1,4 @@
-setenv bootargs $bootargs root=/dev/mmcblk0p2 rw rootwait earlycon clk_ignore_unused
-fatload mmc 0 @@DEVICETREE_ADDRESS@@ @@DEVICE_TREE_NAME@@
+setenv bootargs $bootargs root=/dev/mmcblk${sdbootdev}p2 rw rootwait earlycon clk_ignore_unused
+fatload mmc $sdbootdev @@DEVICETREE_ADDRESS@@ @@DEVICE_TREE_NAME@@
 fatload mmc $sdbootdev:$partid @@KERNEL_LOAD_ADDRESS@@ @@KERNEL_IMAGETYPE@@
 @@KERNEL_BOOTCMD@@ @@KERNEL_LOAD_ADDRESS@@ - @@DEVICETREE_ADDRESS@@


### PR DESCRIPTION
As agreed in #17, remove from the pull request Luca's patch which is part of u-boot_v2019.2 now. Apply changes on top of master-next.