### PR TITLE
meta-xilinx-bsp depends on meta-xilinx-tools. Update layer.conf.

### DIFF
--- a/meta-xilinx-bsp/conf/layer.conf
+++ b/meta-xilinx-bsp/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "xilinx"
 BBFILE_PATTERN_xilinx = "^${LAYERDIR}/"
 BBFILE_PRIORITY_xilinx = "5"
 
-LAYERDEPENDS_xilinx = "core"
+LAYERDEPENDS_xilinx = "core xilinx-tools"
 
 LAYERSERIES_COMPAT_xilinx = "dunfell gatesgarth"
 


### PR DESCRIPTION
Signed-off-by: Philip Balister <philip@opensdr.com>