### PR TITLE
gdb: Fix on-target GDB compilation

### DIFF
--- a/meta-microblaze/recipes-devtools/binutils/binutils-microblaze.inc
+++ b/meta-microblaze/recipes-devtools/binutils/binutils-microblaze.inc
@@ -53,6 +53,7 @@ SRC_URI_append = " \
      file://0050-opcodes-microblaze-dis.c-Fix-compile-warnings.patch \
      file://0051-gdb-microblaze-tdep.c-Remove-unused-functions.patch \
      file://0052-sim-Allow-microblaze-architecture.patch \
+     file://0053-gdb-Fix-microblaze-target-compilation.patch \
      "
 
 #

--- a/meta-microblaze/recipes-devtools/binutils/binutils/0053-gdb-Fix-microblaze-target-compilation.patch
+++ b/meta-microblaze/recipes-devtools/binutils/binutils/0053-gdb-Fix-microblaze-target-compilation.patch
@@ -1,0 +1,288 @@
+From efa3750ffda1ae16caf071b8b8ea31f752a3324a Mon Sep 17 00:00:00 2001
+From: Mark Hatle <mark.hatle@kernel.crashing.org>
+Date: Mon, 7 Dec 2020 12:03:25 -0600
+Subject: [PATCH] gdb: Fix microblaze target compilation
+
+Add microblaze-linux-nat.c to configure.nat
+
+Transition microblaze-linux-nat.c to use the new gdb C++ style functions.
+
+Signed-off-by: Mark Hatle <mark.hatle@kernel.crashing.org>
+---
+ gdb/configure.nat          |  5 ++
+ gdb/microblaze-linux-nat.c | 96 ++++++++++++++------------------------
+ gdb/microblaze-tdep.h      |  3 ++
+ 3 files changed, 43 insertions(+), 61 deletions(-)
+
+diff --git a/gdb/configure.nat b/gdb/configure.nat
+index 6ea2583495..1fba80f6c9 100644
+--- a/gdb/configure.nat
++++ b/gdb/configure.nat
+@@ -261,6 +261,11 @@ case ${gdb_host} in
+ 		# Host: Motorola m68k running GNU/Linux.
+ 		NATDEPFILES="${NATDEPFILES} m68k-linux-nat.o"
+ 		;;
++	    microblaze)
++		# Host: Microblaze running GNU/Linux.
++		NATDEPFILES="${NATDEPFILES} microblaze-linux-nat.o"
++		NAT_CDEPS=
++		;;
+ 	    mips)
+ 		# Host: Linux/MIPS
+ 		NATDEPFILES="${NATDEPFILES} linux-nat-trad.o \
+diff --git a/gdb/microblaze-linux-nat.c b/gdb/microblaze-linux-nat.c
+index e9b8c9c522..bac4697e1e 100644
+--- a/gdb/microblaze-linux-nat.c
++++ b/gdb/microblaze-linux-nat.c
+@@ -36,13 +36,14 @@
+ #include "dwarf2-frame.h"
+ #include "osabi.h"
+ 
+-#include "gdb_assert.h"
+-#include "gdb_string.h"
++#include "gdbsupport/gdb_assert.h"
++#include <string.h>
+ #include "target-descriptions.h"
+ #include "opcodes/microblaze-opcm.h"
+ #include "opcodes/microblaze-dis.h"
+ 
+ #include "linux-nat.h"
++#include "linux-tdep.h"
+ #include "target-descriptions.h"
+ 
+ #include <sys/user.h>
+@@ -61,22 +62,17 @@
+ /* Defines ps_err_e, struct ps_prochandle.  */
+ #include "gdb_proc_service.h"
+ 
+-/* On GNU/Linux, threads are implemented as pseudo-processes, in which
+-   case we may be tracing more than one process at a time.  In that
+-   case, inferior_ptid will contain the main process ID and the
+-   individual thread (process) ID.  get_thread_id () is used to get
+-   the thread id if it's available, and the process id otherwise.  */
+-
+-int
+-get_thread_id (ptid_t ptid)
++class microblaze_linux_nat_target final : public linux_nat_target
+ {
+-  int tid = TIDGET (ptid);
+-  if (0 == tid)
+-    tid = PIDGET (ptid);
+-  return tid;
+-}
++public:
++  /* Add our register access methods.  */
++  void fetch_registers (struct regcache *, int) override;
++  void store_registers (struct regcache *, int) override;
++
++  const struct target_desc *read_description () override;
++};
+ 
+-#define GET_THREAD_ID(PTID)	get_thread_id (PTID)
++static microblaze_linux_nat_target the_microblaze_linux_nat_target;
+ 
+ /* Non-zero if our kernel may support the PTRACE_GETREGS and
+    PTRACE_SETREGS requests, for reading and writing the
+@@ -88,7 +84,6 @@ static int
+ microblaze_register_u_addr (struct gdbarch *gdbarch, int regno)
+ {
+   int u_addr = -1;
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   /* NOTE: cagney/2003-11-25: This is the word size used by the ptrace
+      interface, and not the wordsize of the program's ABI.  */
+   int wordsize = sizeof (long);
+@@ -105,18 +100,16 @@ microblaze_register_u_addr (struct gdbarch *gdbarch, int regno)
+ static void
+ fetch_register (struct regcache *regcache, int tid, int regno)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
++  struct gdbarch *gdbarch = regcache->arch ();
+   /* This isn't really an address.  But ptrace thinks of it as one.  */
+   CORE_ADDR regaddr = microblaze_register_u_addr (gdbarch, regno);
+   int bytes_transferred;
+-  unsigned int offset;         /* Offset of registers within the u area.  */
+-  char buf[MAX_REGISTER_SIZE];
++  char buf[MICROBLAZE_MAX_REGISTER_SIZE];
+ 
+   if (regaddr == -1)
+   {
+     memset (buf, '\0', register_size (gdbarch, regno));   /* Supply zeroes */
+-    regcache_raw_supply (regcache, regno, buf);
++    regcache->raw_supply (regno, buf);
+     return;
+   }
+ 
+@@ -149,14 +142,14 @@ fetch_register (struct regcache *regcache, int tid, int regno)
+   {
+     /* Little-endian values are always found at the left end of the
+        bytes transferred.  */
+-    regcache_raw_supply (regcache, regno, buf);
++    regcache->raw_supply (regno, buf);
+   }
+   else if (gdbarch_byte_order (gdbarch) == BFD_ENDIAN_BIG)
+   {
+     /* Big-endian values are found at the right end of the bytes
+        transferred.  */
+     size_t padding = (bytes_transferred - register_size (gdbarch, regno));
+-    regcache_raw_supply (regcache, regno, buf + padding);
++    regcache->raw_supply (regno, buf + padding);
+   }
+   else
+     internal_error (__FILE__, __LINE__,
+@@ -175,8 +168,6 @@ fetch_register (struct regcache *regcache, int tid, int regno)
+ static int
+ fetch_all_gp_regs (struct regcache *regcache, int tid)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   gdb_gregset_t gregset;
+ 
+   if (ptrace (PTRACE_GETREGS, tid, 0, (void *) &gregset) < 0)
+@@ -204,8 +195,6 @@ fetch_all_gp_regs (struct regcache *regcache, int tid)
+ static void
+ fetch_gp_regs (struct regcache *regcache, int tid)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   int i;
+ 
+   if (have_ptrace_getsetregs)
+@@ -223,13 +212,12 @@ fetch_gp_regs (struct regcache *regcache, int tid)
+ static void
+ store_register (const struct regcache *regcache, int tid, int regno)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
++  struct gdbarch *gdbarch = regcache->arch ();
+   /* This isn't really an address.  But ptrace thinks of it as one.  */
+   CORE_ADDR regaddr = microblaze_register_u_addr (gdbarch, regno);
+   int i;
+   size_t bytes_to_transfer;
+-  char buf[MAX_REGISTER_SIZE];
++  char buf[MICROBLAZE_MAX_REGISTER_SIZE];
+ 
+   if (regaddr == -1)
+     return;
+@@ -242,13 +230,13 @@ store_register (const struct regcache *regcache, int tid, int regno)
+   if (gdbarch_byte_order (gdbarch) == BFD_ENDIAN_LITTLE)
+   {
+     /* Little-endian values always sit at the left end of the buffer.  */
+-    regcache_raw_collect (regcache, regno, buf);
++    regcache->raw_collect (regno, buf);
+   }
+   else if (gdbarch_byte_order (gdbarch) == BFD_ENDIAN_BIG)
+   {
+     /* Big-endian values sit at the right end of the buffer.  */
+     size_t padding = (bytes_to_transfer - register_size (gdbarch, regno));
+-    regcache_raw_collect (regcache, regno, buf + padding);
++    regcache->raw_collect (regno, buf + padding);
+   }
+ 
+   for (i = 0; i < bytes_to_transfer; i += sizeof (long))
+@@ -281,8 +269,6 @@ store_register (const struct regcache *regcache, int tid, int regno)
+ static int
+ store_all_gp_regs (const struct regcache *regcache, int tid, int regno)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   gdb_gregset_t gregset;
+ 
+   if (ptrace (PTRACE_GETREGS, tid, 0, (void *) &gregset) < 0)
+@@ -319,8 +305,6 @@ store_all_gp_regs (const struct regcache *regcache, int tid, int regno)
+ static void
+ store_gp_regs (const struct regcache *regcache, int tid, int regno)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   int i;
+ 
+   if (have_ptrace_getsetregs)
+@@ -339,12 +323,12 @@ store_gp_regs (const struct regcache *regcache, int tid, int regno)
+    regno == -1, otherwise fetch all general registers or all floating
+    point registers depending upon the value of regno.  */
+ 
+-static void
+-microblaze_linux_fetch_inferior_registers (struct target_ops *ops,
+-				    struct regcache *regcache, int regno)
++void
++microblaze_linux_nat_target::fetch_registers (struct regcache * regcache,
++                                              int regno)
+ {
+   /* Get the thread id for the ptrace call.  */
+-  int tid = GET_THREAD_ID (inferior_ptid);
++  int tid = regcache->ptid ().lwp ();
+ 
+   if (regno == -1)
+     fetch_gp_regs (regcache, tid);
+@@ -356,12 +340,12 @@ microblaze_linux_fetch_inferior_registers (struct target_ops *ops,
+    regno == -1, otherwise store all general registers or all floating
+    point registers depending upon the value of regno.  */
+ 
+-static void
+-microblaze_linux_store_inferior_registers (struct target_ops *ops,
+-				    struct regcache *regcache, int regno)
++void
++microblaze_linux_nat_target::store_registers (struct regcache *regcache,
++                                              int regno)
+ {
+   /* Get the thread id for the ptrace call.  */
+-  int tid = GET_THREAD_ID (inferior_ptid);
++  int tid = regcache->ptid ().lwp ();
+ 
+   if (regno >= 0)
+     store_register (regcache, tid, regno);
+@@ -398,12 +382,12 @@ supply_fpregset (struct regcache *regcache, const gdb_fpregset_t *fpregsetp)
+   /* FIXME. */
+ }
+ 
+-static const struct target_desc *
+-microblaze_linux_read_description (struct target_ops *ops)
++const struct target_desc *
++microblaze_linux_nat_target::read_description ()
+ {
+-  CORE_ADDR microblaze_hwcap = 0;
++  CORE_ADDR microblaze_hwcap = linux_get_hwcap (this);
+ 
+-  if (target_auxv_search (ops, AT_HWCAP, &microblaze_hwcap) != 1)
++  if (microblaze_hwcap != 1)
+     return NULL;
+ 
+   return NULL;
+@@ -415,17 +399,7 @@ void _initialize_microblaze_linux_nat (void);
+ void
+ _initialize_microblaze_linux_nat (void)
+ {
+-  struct target_ops *t;
+-
+-  /* Fill in the generic GNU/Linux methods.  */
+-  t = linux_target ();
+-
+-  /* Add our register access methods.  */
+-  t->to_fetch_registers = microblaze_linux_fetch_inferior_registers;
+-  t->to_store_registers = microblaze_linux_store_inferior_registers;
+-
+-  t->to_read_description = microblaze_linux_read_description;
+-
+   /* Register the target.  */
+-  linux_nat_add_target (t);
++  linux_target = &the_microblaze_linux_nat_target;
++  add_inf_child_target (&the_microblaze_linux_nat_target);
+ }
+diff --git a/gdb/microblaze-tdep.h b/gdb/microblaze-tdep.h
+index c0fc900733..c777d93a95 100644
+--- a/gdb/microblaze-tdep.h
++++ b/gdb/microblaze-tdep.h
+@@ -106,6 +106,9 @@ enum microblaze_regnum
+   MICROBLAZE_NUM_REGS, MICROBLAZE_NUM_CORE_REGS = MICROBLAZE_NUM_REGS
+ };
+ 
++/* Big enough to hold the size of the largest register in bytes.  */
++#define MICROBLAZE_MAX_REGISTER_SIZE   64
++
+ struct microblaze_frame_cache
+ {
+   /* Base address.  */
+-- 
+2.17.1
+

--- a/meta-microblaze/recipes-devtools/gdb/gdb-microblaze.inc
+++ b/meta-microblaze/recipes-devtools/gdb/gdb-microblaze.inc
@@ -48,6 +48,7 @@ SRC_URI_append_microblaze = " \
      file://0050-opcodes-microblaze-dis.c-Fix-compile-warnings.patch \
      file://0051-gdb-microblaze-tdep.c-Remove-unused-functions.patch \
      file://0052-sim-Allow-microblaze-architecture.patch \
+     file://0053-gdb-Fix-microblaze-target-compilation.patch \
      "
 
 #

--- a/meta-microblaze/recipes-devtools/gdb/gdb/0053-gdb-Fix-microblaze-target-compilation.patch
+++ b/meta-microblaze/recipes-devtools/gdb/gdb/0053-gdb-Fix-microblaze-target-compilation.patch
@@ -1,0 +1,288 @@
+From e770e163e918c6065fc437687839bfbbd0137cff Mon Sep 17 00:00:00 2001
+From: Mark Hatle <mark.hatle@kernel.crashing.org>
+Date: Mon, 7 Dec 2020 12:03:25 -0600
+Subject: [PATCH] gdb: Fix microblaze target compilation
+
+Add microblaze-linux-nat.c to configure.nat
+
+Transition microblaze-linux-nat.c to use the new gdb C++ style functions.
+
+Signed-off-by: Mark Hatle <mark.hatle@kernel.crashing.org>
+---
+ gdb/configure.nat          |  5 ++
+ gdb/microblaze-linux-nat.c | 96 ++++++++++++++------------------------
+ gdb/microblaze-tdep.h      |  3 ++
+ 3 files changed, 43 insertions(+), 61 deletions(-)
+
+diff --git a/gdb/configure.nat b/gdb/configure.nat
+index fb4522f579..2b6873f9d6 100644
+--- a/gdb/configure.nat
++++ b/gdb/configure.nat
+@@ -261,6 +261,11 @@ case ${gdb_host} in
+ 		# Host: Motorola m68k running GNU/Linux.
+ 		NATDEPFILES="${NATDEPFILES} m68k-linux-nat.o"
+ 		;;
++	    microblaze)
++		# Host: Microblaze running GNU/Linux.
++		NATDEPFILES="${NATDEPFILES} microblaze-linux-nat.o"
++		NAT_CDEPS=
++		;;
+ 	    mips)
+ 		# Host: Linux/MIPS
+ 		NATDEPFILES="${NATDEPFILES} linux-nat-trad.o \
+diff --git a/gdb/microblaze-linux-nat.c b/gdb/microblaze-linux-nat.c
+index e9b8c9c522..bac4697e1e 100644
+--- a/gdb/microblaze-linux-nat.c
++++ b/gdb/microblaze-linux-nat.c
+@@ -36,13 +36,14 @@
+ #include "dwarf2-frame.h"
+ #include "osabi.h"
+ 
+-#include "gdb_assert.h"
+-#include "gdb_string.h"
++#include "gdbsupport/gdb_assert.h"
++#include <string.h>
+ #include "target-descriptions.h"
+ #include "opcodes/microblaze-opcm.h"
+ #include "opcodes/microblaze-dis.h"
+ 
+ #include "linux-nat.h"
++#include "linux-tdep.h"
+ #include "target-descriptions.h"
+ 
+ #include <sys/user.h>
+@@ -61,22 +62,17 @@
+ /* Defines ps_err_e, struct ps_prochandle.  */
+ #include "gdb_proc_service.h"
+ 
+-/* On GNU/Linux, threads are implemented as pseudo-processes, in which
+-   case we may be tracing more than one process at a time.  In that
+-   case, inferior_ptid will contain the main process ID and the
+-   individual thread (process) ID.  get_thread_id () is used to get
+-   the thread id if it's available, and the process id otherwise.  */
+-
+-int
+-get_thread_id (ptid_t ptid)
++class microblaze_linux_nat_target final : public linux_nat_target
+ {
+-  int tid = TIDGET (ptid);
+-  if (0 == tid)
+-    tid = PIDGET (ptid);
+-  return tid;
+-}
++public:
++  /* Add our register access methods.  */
++  void fetch_registers (struct regcache *, int) override;
++  void store_registers (struct regcache *, int) override;
++
++  const struct target_desc *read_description () override;
++};
+ 
+-#define GET_THREAD_ID(PTID)	get_thread_id (PTID)
++static microblaze_linux_nat_target the_microblaze_linux_nat_target;
+ 
+ /* Non-zero if our kernel may support the PTRACE_GETREGS and
+    PTRACE_SETREGS requests, for reading and writing the
+@@ -88,7 +84,6 @@ static int
+ microblaze_register_u_addr (struct gdbarch *gdbarch, int regno)
+ {
+   int u_addr = -1;
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   /* NOTE: cagney/2003-11-25: This is the word size used by the ptrace
+      interface, and not the wordsize of the program's ABI.  */
+   int wordsize = sizeof (long);
+@@ -105,18 +100,16 @@ microblaze_register_u_addr (struct gdbarch *gdbarch, int regno)
+ static void
+ fetch_register (struct regcache *regcache, int tid, int regno)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
++  struct gdbarch *gdbarch = regcache->arch ();
+   /* This isn't really an address.  But ptrace thinks of it as one.  */
+   CORE_ADDR regaddr = microblaze_register_u_addr (gdbarch, regno);
+   int bytes_transferred;
+-  unsigned int offset;         /* Offset of registers within the u area.  */
+-  char buf[MAX_REGISTER_SIZE];
++  char buf[MICROBLAZE_MAX_REGISTER_SIZE];
+ 
+   if (regaddr == -1)
+   {
+     memset (buf, '\0', register_size (gdbarch, regno));   /* Supply zeroes */
+-    regcache_raw_supply (regcache, regno, buf);
++    regcache->raw_supply (regno, buf);
+     return;
+   }
+ 
+@@ -149,14 +142,14 @@ fetch_register (struct regcache *regcache, int tid, int regno)
+   {
+     /* Little-endian values are always found at the left end of the
+        bytes transferred.  */
+-    regcache_raw_supply (regcache, regno, buf);
++    regcache->raw_supply (regno, buf);
+   }
+   else if (gdbarch_byte_order (gdbarch) == BFD_ENDIAN_BIG)
+   {
+     /* Big-endian values are found at the right end of the bytes
+        transferred.  */
+     size_t padding = (bytes_transferred - register_size (gdbarch, regno));
+-    regcache_raw_supply (regcache, regno, buf + padding);
++    regcache->raw_supply (regno, buf + padding);
+   }
+   else
+     internal_error (__FILE__, __LINE__,
+@@ -175,8 +168,6 @@ fetch_register (struct regcache *regcache, int tid, int regno)
+ static int
+ fetch_all_gp_regs (struct regcache *regcache, int tid)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   gdb_gregset_t gregset;
+ 
+   if (ptrace (PTRACE_GETREGS, tid, 0, (void *) &gregset) < 0)
+@@ -204,8 +195,6 @@ fetch_all_gp_regs (struct regcache *regcache, int tid)
+ static void
+ fetch_gp_regs (struct regcache *regcache, int tid)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   int i;
+ 
+   if (have_ptrace_getsetregs)
+@@ -223,13 +212,12 @@ fetch_gp_regs (struct regcache *regcache, int tid)
+ static void
+ store_register (const struct regcache *regcache, int tid, int regno)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
++  struct gdbarch *gdbarch = regcache->arch ();
+   /* This isn't really an address.  But ptrace thinks of it as one.  */
+   CORE_ADDR regaddr = microblaze_register_u_addr (gdbarch, regno);
+   int i;
+   size_t bytes_to_transfer;
+-  char buf[MAX_REGISTER_SIZE];
++  char buf[MICROBLAZE_MAX_REGISTER_SIZE];
+ 
+   if (regaddr == -1)
+     return;
+@@ -242,13 +230,13 @@ store_register (const struct regcache *regcache, int tid, int regno)
+   if (gdbarch_byte_order (gdbarch) == BFD_ENDIAN_LITTLE)
+   {
+     /* Little-endian values always sit at the left end of the buffer.  */
+-    regcache_raw_collect (regcache, regno, buf);
++    regcache->raw_collect (regno, buf);
+   }
+   else if (gdbarch_byte_order (gdbarch) == BFD_ENDIAN_BIG)
+   {
+     /* Big-endian values sit at the right end of the buffer.  */
+     size_t padding = (bytes_to_transfer - register_size (gdbarch, regno));
+-    regcache_raw_collect (regcache, regno, buf + padding);
++    regcache->raw_collect (regno, buf + padding);
+   }
+ 
+   for (i = 0; i < bytes_to_transfer; i += sizeof (long))
+@@ -281,8 +269,6 @@ store_register (const struct regcache *regcache, int tid, int regno)
+ static int
+ store_all_gp_regs (const struct regcache *regcache, int tid, int regno)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   gdb_gregset_t gregset;
+ 
+   if (ptrace (PTRACE_GETREGS, tid, 0, (void *) &gregset) < 0)
+@@ -319,8 +305,6 @@ store_all_gp_regs (const struct regcache *regcache, int tid, int regno)
+ static void
+ store_gp_regs (const struct regcache *regcache, int tid, int regno)
+ {
+-  struct gdbarch *gdbarch = get_regcache_arch (regcache);
+-  struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+   int i;
+ 
+   if (have_ptrace_getsetregs)
+@@ -339,12 +323,12 @@ store_gp_regs (const struct regcache *regcache, int tid, int regno)
+    regno == -1, otherwise fetch all general registers or all floating
+    point registers depending upon the value of regno.  */
+ 
+-static void
+-microblaze_linux_fetch_inferior_registers (struct target_ops *ops,
+-				    struct regcache *regcache, int regno)
++void
++microblaze_linux_nat_target::fetch_registers (struct regcache * regcache,
++                                              int regno)
+ {
+   /* Get the thread id for the ptrace call.  */
+-  int tid = GET_THREAD_ID (inferior_ptid);
++  int tid = regcache->ptid ().lwp ();
+ 
+   if (regno == -1)
+     fetch_gp_regs (regcache, tid);
+@@ -356,12 +340,12 @@ microblaze_linux_fetch_inferior_registers (struct target_ops *ops,
+    regno == -1, otherwise store all general registers or all floating
+    point registers depending upon the value of regno.  */
+ 
+-static void
+-microblaze_linux_store_inferior_registers (struct target_ops *ops,
+-				    struct regcache *regcache, int regno)
++void
++microblaze_linux_nat_target::store_registers (struct regcache *regcache,
++                                              int regno)
+ {
+   /* Get the thread id for the ptrace call.  */
+-  int tid = GET_THREAD_ID (inferior_ptid);
++  int tid = regcache->ptid ().lwp ();
+ 
+   if (regno >= 0)
+     store_register (regcache, tid, regno);
+@@ -398,12 +382,12 @@ supply_fpregset (struct regcache *regcache, const gdb_fpregset_t *fpregsetp)
+   /* FIXME. */
+ }
+ 
+-static const struct target_desc *
+-microblaze_linux_read_description (struct target_ops *ops)
++const struct target_desc *
++microblaze_linux_nat_target::read_description ()
+ {
+-  CORE_ADDR microblaze_hwcap = 0;
++  CORE_ADDR microblaze_hwcap = linux_get_hwcap (this);
+ 
+-  if (target_auxv_search (ops, AT_HWCAP, &microblaze_hwcap) != 1)
++  if (microblaze_hwcap != 1)
+     return NULL;
+ 
+   return NULL;
+@@ -415,17 +399,7 @@ void _initialize_microblaze_linux_nat (void);
+ void
+ _initialize_microblaze_linux_nat (void)
+ {
+-  struct target_ops *t;
+-
+-  /* Fill in the generic GNU/Linux methods.  */
+-  t = linux_target ();
+-
+-  /* Add our register access methods.  */
+-  t->to_fetch_registers = microblaze_linux_fetch_inferior_registers;
+-  t->to_store_registers = microblaze_linux_store_inferior_registers;
+-
+-  t->to_read_description = microblaze_linux_read_description;
+-
+   /* Register the target.  */
+-  linux_nat_add_target (t);
++  linux_target = &the_microblaze_linux_nat_target;
++  add_inf_child_target (&the_microblaze_linux_nat_target);
+ }
+diff --git a/gdb/microblaze-tdep.h b/gdb/microblaze-tdep.h
+index c0fc900733..c777d93a95 100644
+--- a/gdb/microblaze-tdep.h
++++ b/gdb/microblaze-tdep.h
+@@ -106,6 +106,9 @@ enum microblaze_regnum
+   MICROBLAZE_NUM_REGS, MICROBLAZE_NUM_CORE_REGS = MICROBLAZE_NUM_REGS
+ };
+ 
++/* Big enough to hold the size of the largest register in bytes.  */
++#define MICROBLAZE_MAX_REGISTER_SIZE   64
++
+ struct microblaze_frame_cache
+ {
+   /* Base address.  */
+-- 
+2.17.1
+


### PR DESCRIPTION
Target gdb/gdbserver failed to compile due to out of date
microblaze-linux-nat.c, correct this and ancillary files.  Note, this only
corrects compilation the code may not function properly.

Signed-off-by: Mark Hatle <mark.hatle@kernel.crashing.org>