### PR TITLE
picozed-zynq7.dts: add marvell,88e1510 to eth phy

### DIFF
--- a/meta-xilinx-bsp/recipes-bsp/device-tree/files/picozed-zynq7.dts
+++ b/meta-xilinx-bsp/recipes-bsp/device-tree/files/picozed-zynq7.dts
@@ -34,7 +34,7 @@
 	phy-handle = <&ethernet_phy>;
 
 	ethernet_phy: ethernet-phy@0 {
-		compatible = "marvell,88e1512";
+		compatible = "marvell,88e1512", "marvell,88e1510";
 		device_type = "ethernet-phy";
 		reg = <0>;
 	};


### PR DESCRIPTION
This was needed to have working ethernet on my picozed-7030