### PR TITLE
Fix build for openembedded-core and gcc-10

### DIFF
--- a/meta-xilinx-bsp/recipes-bsp/u-boot/files/0001-Remove-redundant-YYLOC-global-declaration.patch
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/files/0001-Remove-redundant-YYLOC-global-declaration.patch
@@ -1,0 +1,28 @@
+From 8127b19aa42ccfb3faae1173a12b3eb0cebf8941 Mon Sep 17 00:00:00 2001
+From: Peter Robinson <pbrobinson@gmail.com>
+Date: Thu, 30 Jan 2020 09:37:15 +0000
+Subject: [PATCH] Remove redundant YYLOC global declaration
+
+Same as the upstream fix for building dtc with gcc 10.
+
+Signed-off-by: Peter Robinson <pbrobinson@gmail.com>
+State: upstream (e33a814e772cdc36436c8c188d8c42d019fda639)
+---
+ scripts/dtc/dtc-lexer.l | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index fd825ebba6..24af549977 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+2.29.2
+

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx_2020.2.bb
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx_2020.2.bb
@@ -2,6 +2,7 @@ UBOOT_VERSION = "v2020.01"
 
 UBRANCH ?= "xlnx_rebase_v2020.01"
 
+SRC_URI_append = " file://0001-Remove-redundant-YYLOC-global-declaration.patch"
 SRCREV ?= "bb4660c33aa7ea64f78b2682bf0efd56765197d6"
 
 include u-boot-xlnx.inc

--- a/meta-xilinx-bsp/recipes-kernel/linux/linux-xlnx/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch
+++ b/meta-xilinx-bsp/recipes-kernel/linux/linux-xlnx/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch
@@ -1,0 +1,51 @@
+From e33a814e772cdc36436c8c188d8c42d019fda639 Mon Sep 17 00:00:00 2001
+From: Dirk Mueller <dmueller@suse.com>
+Date: Tue, 14 Jan 2020 18:53:41 +0100
+Subject: [PATCH] scripts/dtc: Remove redundant YYLOC global declaration
+
+gcc 10 will default to -fno-common, which causes this error at link
+time:
+
+  (.text+0x0): multiple definition of `yylloc'; dtc-lexer.lex.o (symbol from plugin):(.text+0x0): first defined here
+
+This is because both dtc-lexer as well as dtc-parser define the same
+global symbol yyloc. Before with -fcommon those were merged into one
+defintion. The proper solution would be to to mark this as "extern",
+however that leads to:
+
+  dtc-lexer.l:26:16: error: redundant redeclaration of 'yylloc' [-Werror=redundant-decls]
+   26 | extern YYLTYPE yylloc;
+      |                ^~~~~~
+In file included from dtc-lexer.l:24:
+dtc-parser.tab.h:127:16: note: previous declaration of 'yylloc' was here
+  127 | extern YYLTYPE yylloc;
+      |                ^~~~~~
+cc1: all warnings being treated as errors
+
+which means the declaration is completely redundant and can just be
+dropped.
+
+Signed-off-by: Dirk Mueller <dmueller@suse.com>
+Signed-off-by: David Gibson <david@gibson.dropbear.id.au>
+[robh: cherry-pick from upstream]
+Cc: stable@vger.kernel.org
+Signed-off-by: Rob Herring <robh@kernel.org>
+---
+ scripts/dtc/dtc-lexer.l | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index 5c6c3fd557d7..b3b7270300de 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -23,7 +23,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+2.29.2
+

--- a/meta-xilinx-bsp/recipes-kernel/linux/linux-xlnx_2020.2.bb
+++ b/meta-xilinx-bsp/recipes-kernel/linux/linux-xlnx_2020.2.bb
@@ -10,5 +10,6 @@ SRC_URI_append = " \
        file://0001-perf-tests-bp_account-Make-global-variable-static.patch \
        file://0001-perf-cs-etm-Move-definition-of-traceid_list-global-v.patch \
        file://0001-libtraceevent-Fix-build-with-binutils-2.35.patch \
+       file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
 "
 


### PR DESCRIPTION
Both patches are already upstream, no problems backporting.