### PR TITLE
zybo-z7-zynq7.conf: Add support for Zybo Z7 development board

### DIFF
--- a/meta-xilinx-bsp/conf/machine/zybo-z7-zynq7.conf
+++ b/meta-xilinx-bsp/conf/machine/zybo-z7-zynq7.conf
@@ -1,0 +1,38 @@
+#@TYPE: Machine
+#@NAME: zybo-z7-zynq7
+#@DESCRIPTION: Machine support for ZYBO Z7.
+#
+# For details on the ZYBO Z7 board:
+#     https://reference.digilentinc.com/reference/programmable-logic/zybo-z7/start
+#
+
+SOC_VARIANT ?= "7z"
+
+require conf/machine/include/tune-zynq.inc
+require conf/machine/include/machine-xilinx-overrides.inc
+require conf/machine/include/machine-xilinx-default.inc
+
+MACHINE_FEATURES = "ext2 vfat usbhost usbgadget"
+
+# u-boot configuration
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
+UBOOT_MACHINE = "zynq_zybo_z7_config"
+SPL_BINARY ?= "spl/boot.bin"
+UBOOT_ELF_zynq = "u-boot"
+
+EXTRA_IMAGEDEPENDS += " \
+		u-boot-zynq-uenv \
+		virtual/boot-bin \
+		virtual/bootloader \
+		u-boot-zynq-scr \
+		"
+
+SERIAL_CONSOLE = "115200 ttyPS0"
+
+KERNEL_DEVICETREE = "zynq-zybo-z7.dtb"
+
+IMAGE_BOOT_FILES += " \
+		boot.bin \
+		uEnv.txt \
+		"
+

--- a/meta-xilinx-bsp/conf/machine/zybo-z7-zynq7.conf
+++ b/meta-xilinx-bsp/conf/machine/zybo-z7-zynq7.conf
@@ -15,7 +15,7 @@ require conf/machine/include/machine-xilinx-default.inc
 MACHINE_FEATURES = "ext2 vfat usbhost usbgadget"
 
 # u-boot configuration
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot-xlnx"
 UBOOT_MACHINE = "zynq_zybo_z7_config"
 SPL_BINARY ?= "spl/boot.bin"
 UBOOT_ELF_zynq = "u-boot"

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx-dev.bb
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx-dev.bb
@@ -24,5 +24,6 @@ HAS_PLATFORM_INIT ?= " \
 		zynq_zc702_config \
 		zynq_zc706_config \
 		zynq_zybo_config \
+		zynq_zybo_z7_config \
 		"
 

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx_2019.2.bb
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-xlnx_2019.2.bb
@@ -19,6 +19,7 @@ HAS_PLATFORM_INIT ?= " \
 		zynq_zc702_config \
 		zynq_zc706_config \
 		zynq_zybo_config \
+		zynq_zybo_z7_config \
 		xilinx_zynqmp_zcu102_rev1_0_config \
 		xilinx_zynqmp_zcu106_revA_config \
 		xilinx_zynqmp_zcu104_revC_config \

--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -7,5 +7,6 @@ HAS_PLATFORM_INIT ??= " \
 		zynq_zc702_config \
 		zynq_zc706_config \
 		zynq_zybo_config \
+		zynq_zybo_z7_config \
 		"
 


### PR DESCRIPTION
The Zybo Z7 is a feature-rich, ready-to-use embedded software and
digital circuit development board built around the Xilinx Zynq-7000
family. The Zynq family is based on the Xilinx All Programmable
System-on-Chip (AP SoC) architecture, which tightly integrates a
dual-core ARM Cortex-A9 processor with Xilinx 7-series Field
Programmable Gate Array (FPGA) logic. The Zybo Z7 surrounds the
Zynq with a rich set of multimedia and connectivity peripherals to
create a formidable single-board computer, even before considering the
flexibility and power added by the FPGA. The Zybo Z7's video-capable
feature set, including a MIPI CSI-2 compatible Pcam connector, HDMI
input, HDMI output, and high DDR3L bandwidth, was chosen to make it
an affordable solution for the high end embedded vision applications
that Xilinx FPGAs are popular for. Attaching additional hardware is
made easy by the Zybo Z7's Pmod connectors, allowing access to
Digilent's catalog of over 70 Pmod peripheral boards, including motor
controllers, sensors, displays, and more.

This patch adds machine configuration file for Zybo Z7 development
board with required setting of board specific yocto variables needed
for compilation of bootloader, kernel and device-tree.