### PR TITLE
Added the PRE_BOOTENV variable to the zynqmp boot.cmd template

### DIFF
--- a/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd.zynqmp
+++ b/meta-xilinx-bsp/recipes-bsp/u-boot/u-boot-zynq-scr/boot.cmd.sd.zynqmp
@@ -1,3 +1,5 @@
+@@PRE_BOOTENV@@
+
 setenv sdbootdev @@SDBOOTDEV@@
 setenv bootargs $bootargs root=/dev/mmcblk${sdbootdev}p2 rw rootwait earlycon clk_ignore_unused
 setenv bootargs $bootargs root=/dev/mmcblk0p2 rw rootwait earlycon clk_ignore_unused


### PR DESCRIPTION
For some reason, in the template for zynqmp, the PRE_BOOTENV variable is missing