### PR TITLE
qemu: remove newer OECONF parameters to make qemu-xilinx 5.0 compatib…

### DIFF
--- a/meta-xilinx-bsp/recipes-devtools/qemu/qemu-xilinx-system-native_2021.1.bb
+++ b/meta-xilinx-bsp/recipes-devtools/qemu/qemu-xilinx-system-native_2021.1.bb
@@ -10,8 +10,8 @@ DEPENDS += "pixman-native qemu-xilinx-native"
 
 do_install_append() {
     # The following is also installed by qemu-native
-    rm -f ${D}${datadir}/${BPN}/trace-events-all
-    rm -rf ${D}${datadir}/${BPN}/keymaps
+    rm -f ${D}${datadir}/qemu/trace-events-all
+    rm -rf ${D}${datadir}/qemu/keymaps
     rm -rf ${D}${datadir}/icons
 }
 

--- a/meta-xilinx-bsp/recipes-devtools/qemu/qemu-xilinx.inc
+++ b/meta-xilinx-bsp/recipes-devtools/qemu/qemu-xilinx.inc
@@ -37,6 +37,7 @@ DISABLE_STATIC_pn-${PN} = ""
 PTEST_ENABLED = ""
 
 EXTRA_OECONF_append = " --with-git=/bin/false --disable-git-update"
+EXTRA_OECONF_remove = " --with-suffix=${BPN} --with-git-submodules=ignore --meson=meson"
 
 do_install_append() {
 	# Prevent QA warnings about installed ${localstatedir}/run


### PR DESCRIPTION
…le with hardknott

Remove --with-suffix and --with-git-submodules CONF options to make qemu-xilinx
5.0 buildable with hardknott.  Additionally, clean up do_install_append file
paths

Signed-off-by: Sai Hari Chandana Kalluri <chandana.kalluri@xilinx.com>