### PR TITLE
meta-xilinx-bsp: Update checksums of kc705 reference design download

### DIFF
--- a/meta-xilinx-bsp/recipes-bsp/reference-design/kc705-bitstream_2020.2.bb
+++ b/meta-xilinx-bsp/recipes-bsp/reference-design/kc705-bitstream_2020.2.bb
@@ -16,8 +16,8 @@ inherit xilinx-fetch-restricted
 BSP_NAME = "xilinx-kc705"
 BSP_FILE = "${BSP_NAME}-v${PV}-final.bsp"
 SRC_URI = "https://www.xilinx.com/member/forms/download/xef.html?filename=${BSP_FILE};downloadfilename=${BSP_FILE}"
-SRC_URI[md5sum] = "5c0365a8a26cc27b4419aa1d7dd82351"
-SRC_URI[sha256sum] = "a909a91a37a9925ee2f972ccb10f986a26ff9785c1a71a483545a192783bf773"
+SRC_URI[md5sum] = "91f88474c2d492558bcabf3d73a66332"
+SRC_URI[sha256sum] = "880c38670b24a5bcce5de0cfdb176ffaf2cb260b6f03b239450a16cf0a6c2fc2"
 
 PROVIDES = "virtual/bitstream"
 
@@ -31,7 +31,7 @@ DEPENDS += "tar-native gzip-native"
 
 do_compile() {
 	# Extract the bitstream into workdir
-	tar -xf ${WORKDIR}/${BSP_FILE} ${BSP_NAME}-axi-full-${PV}/pre-built/linux/images/download.bit -C ${S}
+	tar -xf ${WORKDIR}/${BSP_FILE} ${BSP_NAME}-${PV}/pre-built/linux/images/download.bit -C ${S}
 	# move the bit file to ${S}/ as it is in a subdir in the tar file
 	for i in $(find -type f -name download.bit); do mv $i ${S}; done
 }


### PR DESCRIPTION
Build tested ok with bitbake core-image-minimal,
MACHINE = kc705-microblazeel
LICENSE_FLAGS_WHITELIST += "xilinx"
BBLAYERS ?= " \
  /home/sune/Yocto/poky/meta \
  /home/sune/Yocto/poky/meta-poky \
  /home/sune/Yocto/poky/meta-xilinx/meta-xilinx-bsp \
  /home/sune/Yocto/poky/meta-xilinx/meta-microblaze \
"
Booting from JTAG (following README.booting) does _not_ work,
possibly due to a wrong default u-boot-xlnx configuration?

The RAM should start at 0x80000000 according to the .dts
included in xilinx-kc705-v2020.2-final.bsp:

memory@80000000 {
		device_type = "memory";
		reg = <0x80000000 0x40000000>;
};

But the generated u-boot.elf, is loaded to address 0x29000000:

readelf -S tmp/deploy/images/kc705-microblazeel/u-boot.elf
There are 24 section headers, starting at offset 0x393a04:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .text             PROGBITS        29000000 001000 0783f0 00  AX  0   0  4
  [ 2] .rodata           PROGBITS        290783f0 0793f0 012010 00   A  0   0  8
  [ 3] .dtb.init.rodata  PROGBITS        2908a400 08b400 0010f0 00   A  0   0 16
...