### PR TITLE
bootbin: Adjust BIF_PARTITION_ATTR in machine-xilinx-zynq.inc

### DIFF
--- a/meta-xilinx-bsp/recipes-bsp/bootbin/machine-xilinx-zynq.inc
+++ b/meta-xilinx-bsp/recipes-bsp/bootbin/machine-xilinx-zynq.inc
@@ -1,5 +1,5 @@
 #specify BIF partition attributes required for BOOT.bin
-BIF_PARTITION_ATTR ?= "fsbl bitstream u-boot"
+BIF_PARTITION_ATTR ?= "fsbl bitstream u-boot-xlnx"
 
 #specify BIF partition attributes for FSBL
 #bootloader is FSBL. Location where FSBL binary is present and dependency to build FSBL
@@ -9,8 +9,8 @@ BIF_PARTITION_DEPENDS[fsbl] ?= "virtual/fsbl:do_deploy"
 
 #specify BIF partition attributes for u-boot
 #Location where u-boot binary is present
-BIF_PARTITION_IMAGE[u-boot] ?= "${DEPLOY_DIR_IMAGE}/u-boot-${MACHINE}.elf"
-BIF_PARTITION_DEPENDS[u-boot] ?= "virtual/bootloader:do_deploy"
+BIF_PARTITION_IMAGE[u-boot-xlnx] ?= "${DEPLOY_DIR_IMAGE}/u-boot-${MACHINE}.elf"
+BIF_PARTITION_DEPENDS[u-boot-xlnx] ?= "virtual/bootloader:do_deploy"
 
 # enable bitstream-Note this is not enabled by default (missing in BIF_PARTITION_ATTR)
 BIF_PARTITION_IMAGE[bitstream] ?= "${DEPLOY_DIR_IMAGE}/download-${MACHINE}.bit"

--- a/meta-xilinx-bsp/recipes-bsp/bootbin/machine-xilinx-zynq.inc
+++ b/meta-xilinx-bsp/recipes-bsp/bootbin/machine-xilinx-zynq.inc
@@ -4,12 +4,12 @@ BIF_PARTITION_ATTR ?= "fsbl bitstream u-boot-xlnx"
 #specify BIF partition attributes for FSBL
 #bootloader is FSBL. Location where FSBL binary is present and dependency to build FSBL
 BIF_PARTITION_ATTR[fsbl] ?= "bootloader"
-BIF_PARTITION_IMAGE[fsbl] ?= "${DEPLOY_DIR_IMAGE}/fsbl-${MACHINE}.elf"
+BIF_PARTITION_IMAGE[fsbl] ?= "${RECIPE_SYSROOT}/boot/fsbl.elf"
 BIF_PARTITION_DEPENDS[fsbl] ?= "virtual/fsbl:do_deploy"
 
 #specify BIF partition attributes for u-boot
 #Location where u-boot binary is present
-BIF_PARTITION_IMAGE[u-boot-xlnx] ?= "${DEPLOY_DIR_IMAGE}/u-boot-${MACHINE}.elf"
+BIF_PARTITION_IMAGE[u-boot-xlnx] ?= "${RECIPE_SYSROOT}/boot/u-boot.elf"
 BIF_PARTITION_DEPENDS[u-boot-xlnx] ?= "virtual/bootloader:do_deploy"
 
 # enable bitstream-Note this is not enabled by default (missing in BIF_PARTITION_ATTR)


### PR DESCRIPTION
u-boot was renamed to u-boot-xlnx, it was fixed in this pull-request
@mhatle please merge it