### PR TITLE
zynqmp-generic.conf: add boot.bin for wks

### DIFF
--- a/meta-xilinx-core/conf/machine/zynqmp-generic.conf
+++ b/meta-xilinx-core/conf/machine/zynqmp-generic.conf
@@ -55,6 +55,7 @@ EXTRA_IMAGEDEPENDS += " \
 		"
 
 IMAGE_BOOT_FILES += " \
+		boot.bin \
 		uEnv.txt \
 		atf-uboot.ub \
 		${@bb.utils.contains('PREFERRED_PROVIDER_virtual/dtb', 'device-tree', 'system.dtb', '', d)} \


### PR DESCRIPTION
wks needs all files that need to appear in boot partition to be added to
the IMAGE_BOOT_FILES variable. This is missing from the zynqmp family
hence add it here.