### PR TITLE
Use weak default value for HDF_MACHINE

### DIFF
--- a/meta-xilinx-core/conf/machine/microblaze-generic.conf
+++ b/meta-xilinx-core/conf/machine/microblaze-generic.conf
@@ -46,7 +46,7 @@ UBOOT_MACHINE ?= "microblaze-generic_defconfig"
 UBOOT_INITIAL_ENV = ""
 BOOTMODE ?= "generic.root"
 
-HDF_MACHINE = "kc705-microblazeel"
+HDF_MACHINE ??= "kc705-microblazeel"
 IMAGE_FSTYPES += "cpio.gz"
 
 QB_KERNEL_CMDLINE = "none"

--- a/meta-xilinx-core/conf/machine/versal-generic.conf
+++ b/meta-xilinx-core/conf/machine/versal-generic.conf
@@ -26,7 +26,7 @@ SERIAL_CONSOLES ?= "115200;ttyAMA0"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "device-tree"
 
-HDF_MACHINE = "vck190-versal"
+HDF_MACHINE ??= "vck190-versal"
 
 # Default SD image build onfiguration, use qemu-sd to pad
 IMAGE_CLASSES += "image-types-xilinx-qemu"

--- a/meta-xilinx-core/conf/machine/versal-net-generic.conf
+++ b/meta-xilinx-core/conf/machine/versal-net-generic.conf
@@ -19,7 +19,7 @@ MACHINEOVERRIDES:class-native = "versal-net"
 MACHINEOVERRIDES:class-nativesdk = "versal-net"
 #### REMOVE THE ABOVE
 
-HDF_MACHINE = "versal-net-generic"
+HDF_MACHINE ??= "versal-net-generic"
 
 QEMU_HW_DTB_PS =  "${QEMU_HW_DTB_PATH}/board-versal-net-psx-spp-1.4.dtb"
 QEMU_HW_DTB_PMC = "${QEMU_HW_DTB_PATH}/board-versal-pmx-virt.dtb"

--- a/meta-xilinx-core/conf/machine/zynq-generic.conf
+++ b/meta-xilinx-core/conf/machine/zynq-generic.conf
@@ -31,7 +31,7 @@ IMAGE_BOOT_FILES += " \
                 boot.scr \
                 "
 
-HDF_MACHINE = "zc702-zynq7"
+HDF_MACHINE ??= "zc702-zynq7"
 IMAGE_CLASSES += "image-types-xilinx-qemu"
 # Add wic.qemu-sd only if initramfs_image not set due to circular dependecies
 IMAGE_FSTYPES += "${@'wic.qemu-sd' if (d.getVar('INITRAMFS_IMAGE') or '') == '' else 'cpio.gz'}"

--- a/meta-xilinx-core/conf/machine/zynqmp-generic.conf
+++ b/meta-xilinx-core/conf/machine/zynqmp-generic.conf
@@ -44,7 +44,7 @@ SERIAL_CONSOLES ?= "115200;ttyPS0"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "device-tree"
 
 # We need a generic one that works with QEMU...
-HDF_MACHINE = "zcu102-zynqmp"
+HDF_MACHINE ??= "zcu102-zynqmp"
 
 EXTRA_IMAGEDEPENDS += " \
 		u-boot-zynq-uenv \


### PR DESCRIPTION
HDF_MACHINE value must be assigned in weak mode in generic.conf files to be able to use any own HDF_MACHINE value in a custom machine conf file, like was demonstrated in [README.md of machines](https://github.com/Xilinx/meta-xilinx/blob/rel-v2022.2/meta-xilinx-core/conf/machine/README).