### PR TITLE
qemu-xilinx-native: filter --disable-jack option

### DIFF
--- a/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-native.inc
+++ b/meta-xilinx-core/recipes-devtools/qemu/qemu-xilinx-native.inc
@@ -6,6 +6,9 @@ DEPENDS = "glib-2.0-native zlib-native ninja-native meson-native"
 SRC_URI:remove = "file://0012-fix-libcap-header-issue-on-some-distro.patch"
 SRC_URI:remove = "file://0013-cpus.c-Add-error-messages-when-qemi_cpu_kick_thread-.patch"
 
+# this option is not supported by qemu-xilinx and will cause a build failure
+EXTRA_OECONF:remove = "--disable-jack"
+
 do_install:append(){
        rm -rf ${D}${datadir}/icons
 }


### PR DESCRIPTION
qemu-xilinx-native does not support jack, thus --disable-jack set by qemu.inc is not supported and will cause:
 ERROR: unknown option --disable-jack
This will filter this option.