### PR TITLE
mesa: fix QA error of patch status

### DIFF
--- a/meta-xilinx-core/recipes-graphics/mesa/files/0001-DRI_Add_xlnx_dri.patch
+++ b/meta-xilinx-core/recipes-graphics/mesa/files/0001-DRI_Add_xlnx_dri.patch
@@ -2,6 +2,8 @@ DRI: Add xlnx dri
 
 Add the Xilinx dri target
 
+Upstream-Status: Pending
+
 Signed-off-by: Mark Hatle <mark.hatle@amd.com>
 
 diff -ur mesa-22.2.0.orig/src/gallium/targets/dri/meson.build mesa-22.2.0/src/gallium/targets/dri/meson.build


### PR DESCRIPTION
In master OE all the patch files are expected to have 'Upstream-Status:' field.

More details:
https://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines#Patch_Header_Recommendations:_Upstream-Status

Signed-off-by: Javier Tia <javier.tia@linaro.org>
