### PR TITLE
u-boot-tools-xlnx: add missing dependencies

### DIFF
--- a/meta-xilinx-core/recipes-bsp/u-boot/u-boot-tools-xlnx_2023.1.bb
+++ b/meta-xilinx-core/recipes-bsp/u-boot/u-boot-tools-xlnx_2023.1.bb
@@ -1,6 +1,8 @@
 require u-boot-tools-xlnx.inc
 require u-boot-xlnx-2023.1.inc
 
+DEPENDS += "swig-native util-linux-libuuid gnutls"
+
 # MUST clear CONFIG_VIDEO to avoid a compilation failure trying to construct
 # bmp_logo.h
 SED_CONFIG_EFI:append = ' -e "s/CONFIG_VIDEO=.*/# CONFIG_VIDEO is not set/"'


### PR DESCRIPTION
The issue can be reproduced with:
```
$ bitbake u-boot-tools-xlnx -c compile -f --skip-setscene
```

The swig is needed on the native sysroot:
```
error: command 'swig' failed: No such file or directory
```
The util-linux-libuuid is needed on target sysroot:
```
.../1_v2023.01-xilinx-v2023.1+gitAUTOINC+0c2f5b2994-r0/git/tools/mkeficapsule.c:18:10: fatal error: 'uuid/uuid.h' file not found
```

The gnutls is needed on target sysroot:
```
.../1_v2023.01-xilinx-v2023.1+gitAUTOINC+0c2f5b2994-r0/git/tools/mkeficapsule.c:21:10: fatal error: 'gnutls/gnutls.h' file not found
```