### PR TITLE
fix: Set correct path for dtb file in zybo-zynq7.conf

### DIFF
--- a/meta-xilinx-vendor/conf/machine/zybo-zynq7.conf
+++ b/meta-xilinx-vendor/conf/machine/zybo-zynq7.conf
@@ -15,7 +15,7 @@ EXTRA_IMAGEDEPENDS += " \
 		u-boot-xlnx-uenv \
 		"
 
-KERNEL_DEVICETREE = "zynq-zybo.dtb"
+KERNEL_DEVICETREE = "xilinx/zynq-zybo.dtb"
 
 IMAGE_BOOT_FILES += " \
 		boot.bin \


### PR DESCRIPTION
- When building images with zybo-zynq7 as MACHINE value, it can't find the dtb file. It is looking in `build/tmp/work-shared/zybo-zynq7/kernel-source/arch/arm/boot/dts`. zynq-zybo.dtb is in the `<path>/arch/arm/boot/dts/xilinx` directory.