### PR TITLE
meta-xilinx-core: pmu-rom-native: fix download filename

### DIFF
--- a/meta-xilinx-core/recipes-bsp/pmu-firmware/pmu-rom-native.bb
+++ b/meta-xilinx-core/recipes-bsp/pmu-firmware/pmu-rom-native.bb
@@ -7,7 +7,7 @@ LICENSE = "Proprietary"
 LICENSE_FLAGS = "xilinx"
 LIC_FILES_CHKSUM = "file://PMU_ROM-LICENSE.txt;md5=d43d49bc1eb1c907fc6f4ea75abafdfc"
 
-SRC_URI = "https://www.xilinx.com/bin/public/openDownload?filename=PMU_ROM.tar.gz"
+SRC_URI = "https://www.xilinx.com/bin/public/openDownload?filename=PMU_ROM.tar.gz;downloadfilename=PMU_ROM.tar.gz"
 SRC_URI[sha256sum] = "f9a450ef960979463ea0a87a35fafb4a5b62d3a741de30cbcef04c8edc22a7cf"
 
 S = "${UNPACKDIR}/PMU_ROM"


### PR DESCRIPTION
When building pmu-rom-native with PMU_ROM.tar.gz not already in the downloads/ folder PMU_ROM.tar.gz is fetched and saved under the filename "openDownload" and thus is not extracted:

```
oe@c6a6840a9726:~/build$ rm -f downloads/PMU_ROM.tar.gz* downloads/openDownload*
oe@c6a6840a9726:~/build$ bitbake pmu-rom-native -c cleanall
oe@c6a6840a9726:~/build$ bitbake pmu-rom-native
[...]
WARNING: pmu-rom-native-1.0-r0 do_populate_lic: Could not copy license file /home/oe/build/tmp-glibc/work/x86_64-linux/pmu-rom-native/1.0/PMU_ROM/PMU_ROM-LICENSE.txt to /home/oe/build/tmp-glibc/work/x86_64-linux/pmu-rom-native/1.0/license-destdir/native/pmu-rom-native/PMU_ROM-LICENSE.txt: [Errno 2] No such file or directory: '/home/oe/build/tmp-glibc/work/x86_64-linux/pmu-rom-native/1.0/PMU_ROM/PMU_ROM-LICENSE.txt'
ERROR: pmu-rom-native-1.0-r0 do_populate_lic: QA Issue: pmu-rom-native: LIC_FILES_CHKSUM points to an invalid file: /home/oe/build/tmp-glibc/work/x86_64-linux/pmu-rom-native/1.0/PMU_ROM/PMU_ROM-LICENSE.txt [license-checksum]
ERROR: pmu-rom-native-1.0-r0 do_populate_lic: Fatal QA errors were found, failing task.
ERROR: Logfile of failure stored in: /home/oe/build/tmp-glibc/work/x86_64-linux/pmu-rom-native/1.0/temp/log.do_populate_lic.177645
ERROR: Task (/home/oe/build/../layers/meta-xilinx/meta-xilinx-core/recipes-bsp/pmu-firmware/pmu-rom-native.bb:do_populate_lic) failed with exit code '1'
NOTE: Tasks Summary: Attempted 19 tasks of which 10 didn't need to be rerun and 1 failed.
[...]

oe@c6a6840a9726:~/build$ ls downloads/openDownload* downloads/PMU_ROM.tar.gz
ls: cannot access 'downloads/PMU_ROM.tar.gz': No such file or directory
downloads/openDownload	downloads/openDownload.done

# openDownload is the correct archive, but with the wrong name
oe@c6a6840a9726:~/build$ tar tf downloads/openDownload
PMU_ROM/
PMU_ROM/pmu-rom.elf
PMU_ROM/PMU_ROM-LICENSE.txt

# without proper filename suffix "openDownload" is not extracted as source
oe@c6a6840a9726:~/build$ find /home/oe/build/tmp-glibc/work/x86_64-linux/pmu-rom-native/1.0/PMU_ROM
/home/oe/build/tmp-glibc/work/x86_64-linux/pmu-rom-native/1.0/PMU_ROM
```

fix: append "downloadfilename=PMU_ROM.tar.gz" to force the proper filename for the downloaded archive, irrespective of the URL.
