### PR TITLE
fix version of trusted-firmware-a

### DIFF
--- a/meta-amd-zephyr/COPYING.MIT
+++ b/meta-amd-zephyr/COPYING.MIT
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+THE SOFTWARE.

--- a/meta-amd-zephyr/README.md
+++ b/meta-amd-zephyr/README.md
@@ -1,0 +1,82 @@
+# meta-amd-zephyr
+
+This layer enables AMD Apdative SoC's Zephyr configurations and features for
+Microblaze-V and Versal devices and also provides related metadata such as system
+device tree(SDT) build metadata such as machine configurations files, multiconfig
+files, system device tree files, kernel configuration fragments, amd zephyr
+drivers and any other libraries.
+
+> **Note:** Additional information on AMD Adaptive SoC's and FPGA's can be found at:
+	https://www.amd.com/en/products/adaptive-socs-and-fpgas.html
+
+Please see the respective READMEs and docs in the layer subdirectories.
+
+## Maintainers, Mailing list, Patches
+
+Please send any patches, pull requests, comments or questions for this layer to
+the [meta-xilinx mailing list](https://lists.yoctoproject.org/g/meta-xilinx)
+with ['meta-amd-zephyr'] in the subject:
+
+	meta-xilinx@lists.yoctoproject.org
+
+When sending patches, please make sure the email subject line includes
+`[meta-amd-zephyr][<BRANCH_NAME>][PATCH]` and cc'ing the maintainers.
+
+For more details follow the Yocto Project community patch submission guidelines,
+as described in:
+
+https://docs.yoctoproject.org/dev/contributor-guide/submit-changes.html#
+
+`git send-email --to meta-xilinx@lists.yoctoproject.org *.patch`
+
+> **Note:** When creating patches, please use below format. To follow best practice,
+> if you have more than one patch use `--cover-letter` option while generating the
+> patches. Edit the 0000-cover-letter.patch and change the title and top of the
+> body as appropriate.
+
+**Syntax:**
+`git format-patch -s --subject-prefix="meta-amd-zephyr][<BRANCH_NAME>][PATCH" -1`
+
+**Example:**
+`git format-patch -s --subject-prefix="meta-amd-zephyr][scarthgap][PATCH" -1`
+
+**Maintainers:**
+
+	Mark Hatle <mark.hatle@amd.com>
+	Sandeep Gundlupet Raju <sandeep.gundlupet-raju@amd.com>
+	John Toomey <john.toomey@amd.com>
+	Trevor Woerner <trevor.woerner@amd.com>
+---
+
+## Dependencies
+
+This layer depends on:
+
+	URI: https://git.yoctoproject.org/poky
+	layers: meta, meta-poky
+	branch: scarthgap
+
+	URI: https://git.openembedded.org/meta-openembedded
+	layers: meta-oe, meta-python.
+	branch: scarthgap
+
+	URI:
+        https://git.yoctoproject.org/meta-zephyr (official version)
+        https://github.com/Xilinx/meta-zephyr (development and AMD release)
+	layers: meta-zephyr-core, meta-zephyr-bsp.
+	branch: scarthgap or AMD release version (e.g. rel-v2025.1)
+
+	URI:
+        https://git.yoctoproject.org/meta-xilinx (official version)
+        https://github.com/Xilinx/meta-xilinx (development and AMD release)
+	layers: meta-xilinx-core, meta-microblaze.
+	branch: scarthgap or AMD release version (e.g. rel-v2025.1)
+
+	URI:
+        https://git.yoctoproject.org/meta-virtualization (official version)
+        https://github.com/Xilinx/meta-virtualization (development and AMD release)
+	branch: scarthgap or AMD release version (e.g. rel-v2025.1)
+
+	URI: https://git.yoctoproject.org/meta-arm
+	layers: meta-arm, meta-arm-toolchain
+	branch: scarthgap

--- a/meta-amd-zephyr/classes-recipe/amd-zephyr-sdt.bbclass
+++ b/meta-amd-zephyr/classes-recipe/amd-zephyr-sdt.bbclass
@@ -1,0 +1,86 @@
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc.  All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# This bbclass is inherited by zephyr recipes to copy lopper generated files to
+# Zephyr soc and board directory before do_configure task.
+
+DEPENDS += "lopper-native dtc-native python3-dtc-native"
+
+# Set default value to zephyr/soc/xlnx/ directory .
+ZEPHYR_SOC_VENDOR ??= "xlnx"
+
+# Set default value to zephyr/boards/amd/ directory .
+ZEPHYR_BOARD_VENDOR ??= "amd"
+
+# Set default value to zephyr/boards/amd/<board>/<board>.dts file.
+ZEPHYR_BOARD_DTS ??= "${ZEPHYR_BASE}/boards/${ZEPHYR_BOARD_VENDOR}/${BOARD}/${BOARD}.dts"
+
+# Set default value to mbv32 directory .
+ZEPHYR_SOC_FAMILY ??= "mbv32"
+
+# Set default value to zephyr/soc/xlnx/mbv32/Kconfig file.
+ZEPHYR_SOC_KCONFIG ??= "${ZEPHYR_BASE}/soc/${ZEPHYR_SOC_VENDOR}/${ZEPHYR_SOC_FAMILY}/Kconfig"
+
+# Set default value to zephyr/soc/xlnx/mbv32/Kconfig.defconfig file.
+ZEPHYR_SOC_KCONFIG_DEFCONFIG ??= "${ZEPHYR_BASE}/soc/${ZEPHYR_SOC_VENDOR}/${ZEPHYR_SOC_FAMILY}/Kconfig.defconfig"
+
+# Lopper transformed file variables.
+CONFIG_DTFILE ??= "undefined"
+
+ZEPHYR_SDT_SOC_KCONFIG ??= "undefined"
+
+ZEPHYR_SDT_SOC_KCONFIG_DEFCONFIG ??= "undefined"
+
+python do_copy_lopper_zephyr_files() {
+    zephyr_board_dts = d.getVar('ZEPHYR_BOARD_DTS')
+    bb.debug(2, "AMD Zephyr Board DTS File: %s" % (zephyr_board_dts))
+
+    zephyr_soc_kconfig = d.getVar('ZEPHYR_SOC_KCONFIG')
+    bb.debug(2, "AMD Zephyr SoC Kconfig File: %s" % (zephyr_soc_kconfig))
+
+    zephyr_soc_kconfig_defconfig = d.getVar('ZEPHYR_SOC_KCONFIG_DEFCONFIG')
+    bb.debug(2, "AMD Zephyr SoC Kconfig.defconfig File: %s" % (zephyr_soc_kconfig_defconfig))
+
+    zephyr_sdt_board_dts = d.getVar('CONFIG_DTFILE') or ''
+    bb.debug(2, "CONFIG_DTFILE File: %s" % (zephyr_sdt_board_dts))
+
+    zephyr_sdt_soc_kconfig = d.getVar('ZEPHYR_SDT_SOC_KCONFIG') or ''
+    bb.debug(2, "ZEPHYR_SDT_SOC_KCONFIG File: %s" % (zephyr_sdt_soc_kconfig))
+
+    zephyr_sdt_soc_kconfig_defconfig = d.getVar('ZEPHYR_SDT_SOC_KCONFIG_DEFCONFIG') or ''
+    bb.debug(2, "ZEPHYR_SDT_SOC_KCONFIG_DEFCONFIG File: %s" % (zephyr_sdt_soc_kconfig_defconfig))
+
+    # Copy CONFIG_DTFILE to ZEPHYR_BOARD_DTS
+    if os.path.isfile(zephyr_sdt_board_dts) and os.path.isfile(zephyr_board_dts):
+        bb.utils.copyfile(zephyr_sdt_board_dts, zephyr_board_dts)
+        bb.debug(2, "Copy DTS File from %s to %s" \
+            % (zephyr_sdt_board_dts, zephyr_board_dts))
+
+    # Copy ZEPHYR_SDT_SOC_KCONFIG to ZEPHYR_SOC_KCONFIG
+    if os.path.isfile(zephyr_sdt_soc_kconfig) and os.path.isfile(zephyr_soc_kconfig):
+        bb.utils.copyfile(zephyr_sdt_soc_kconfig, zephyr_soc_kconfig)
+        bb.debug(2, "Copy SoC Kconfig File from %s to %s" \
+            % (zephyr_sdt_soc_kconfig, zephyr_soc_kconfig))
+
+    # Copy ZEPHYR_SDT_SOC_KCONFIG_DEFCONFIG to ZEPHYR_SOC_KCONFIG_DEFCONFIG
+    if os.path.isfile(zephyr_sdt_soc_kconfig_defconfig) and os.path.isfile(zephyr_soc_kconfig_defconfig):
+        bb.utils.copyfile(zephyr_sdt_soc_kconfig_defconfig, zephyr_soc_kconfig_defconfig)
+        bb.debug(2, "Copy SoC Kconfig.defconfig from %s to %s" \
+            % (zephyr_sdt_soc_kconfig_defconfig, zephyr_soc_kconfig_defconfig))
+}
+
+do_configure[prefuncs] += "do_copy_lopper_zephyr_files"
+
+def check_zephyr_variables(d):
+    # Don't cache this, as the items on disk can change!
+    d.setVar('BB_DONT_CACHE', '1')
+
+    if not d.getVar('CONFIG_DTFILE'):
+        raise bb.parse.SkipRecipe("CONFIG_DTFILE or ZEPHYR_BOARD_DTS is not defined.")
+
+python() {
+    # Need to allow bbappends to change the check
+    check_zephyr_variables(d)
+}

--- a/meta-amd-zephyr/conf/distro/amd-zephyr.conf
+++ b/meta-amd-zephyr/conf/distro/amd-zephyr.conf
@@ -1,0 +1,4 @@
+require conf/distro/amd-zephyr.inc
+
+# User gets the amd-zephyr distro overrides
+DISTROOVERRIDES =. "amd-zephyr:"

--- a/meta-amd-zephyr/conf/distro/amd-zephyr.inc
+++ b/meta-amd-zephyr/conf/distro/amd-zephyr.inc
@@ -1,0 +1,26 @@
+DISTRO_NAME = "AMD Zephyr Distro"
+DISTRO_VERSION = "1.0"
+TARGET_VENDOR = "-amd"
+
+# Zephyr uses newlib for kernel, drivers and applications.
+TCLIBC ?= "newlib"
+TCLIBCAPPEND =""
+
+TEST_TARGET = "QemuTargetZephyr"
+TEST_SUITES = "zephyr"
+
+INHERIT += "siteinfo-zephyr"
+
+# TODO - Inheriting zephyr-qemuboot bbclass results in parse errors with
+# multiconfig builds. Hence disble it for now.
+# ZEPHYR_INHERIT_CLASSES += "zephyr-qemuboot"
+
+require conf/distro/include/yocto-uninative.inc
+INHERIT += "uninative"
+
+BB_SIGNATURE_HANDLER ?= "OEEquivHash"
+BB_HASHSERVE ??= "auto"
+
+# Use Zephyr SDK toolchain to build application for cortex-r and microblaze-v
+# processor.
+ZEPHYR_TOOLCHAIN_VARIANT = "zephyr"

--- a/meta-amd-zephyr/conf/layer.conf
+++ b/meta-amd-zephyr/conf/layer.conf
@@ -19,3 +19,7 @@ LAYERDEPENDS_amd-zephyr = "\
     "
 
 LAYERSERIES_COMPAT_amd-zephyr = "scarthgap"
+
+# Default to LTS3 3.7.0 version
+AMD_ZEPHYR_VERSION[v2025.1] = "3.7.0"
+PREFERRED_VERSION_zephyr-kernel ?= "${@d.getVarFlag('AMD_ZEPHYR_VERSION', d.getVar('XILINX_RELEASE_VERSION')) or 'undefined'}"

--- a/meta-amd-zephyr/conf/layer.conf
+++ b/meta-amd-zephyr/conf/layer.conf
@@ -23,3 +23,7 @@ LAYERSERIES_COMPAT_amd-zephyr = "scarthgap"
 # Default to LTS3 3.7.0 version
 AMD_ZEPHYR_VERSION[v2025.1] = "3.7.0"
 PREFERRED_VERSION_zephyr-kernel ?= "${@d.getVarFlag('AMD_ZEPHYR_VERSION', d.getVar('XILINX_RELEASE_VERSION')) or 'undefined'}"
+
+# Default to 0.16.8 SDK version
+AMD_ZEPHYR_SDK_VERSION[v2025.1] = "0.16.8"
+PREFERRED_VERSION_zephyr-sdk ?= "${@d.getVarFlag('AMD_ZEPHYR_SDK_VERSION', d.getVar('XILINX_RELEASE_VERSION')) or 'undefined'}"

--- a/meta-amd-zephyr/conf/layer.conf
+++ b/meta-amd-zephyr/conf/layer.conf
@@ -1,0 +1,21 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "amd-zephyr"
+BBFILE_PATTERN_amd-zephyr = "^${LAYERDIR}/"
+BBFILE_PRIORITY_amd-zephyr = "6"
+
+LAYERDEPENDS_amd-zephyr = "\
+    core \
+    meta-python \
+    zephyrcore \
+    xilinx \
+    xilinx-microblaze \
+    virtualization-layer \
+    "
+
+LAYERSERIES_COMPAT_amd-zephyr = "scarthgap"

--- a/meta-amd-zephyr/conf/machine/mbv32.conf
+++ b/meta-amd-zephyr/conf/machine/mbv32.conf
@@ -1,0 +1,14 @@
+#@TYPE: Machine
+#@NAME: mbv32
+#@DESCRIPTION: Machine for Zephyr BOARD mbv32
+
+# This machine file is demostrate building stock zephyr amd mbv32 board using
+# meta-amd-zephyr layer.
+require conf/machine/include/riscv/tune-riscv.inc
+
+DEFAULTTUNE = "riscv32"
+
+# Zephyr RTOS settings
+ZEPHYR_BOARD = "mbv32"
+ARCH:mbv32 = "riscv32"
+DISTRO = "amd-zephyr"

--- a/meta-amd-zephyr/recipes-devtools/zephyr-sdk/zephyr-sdk_0.16.8.bb
+++ b/meta-amd-zephyr/recipes-devtools/zephyr-sdk/zephyr-sdk_0.16.8.bb
@@ -1,0 +1,35 @@
+SUMMARY = "Zephyr SDK Bundle"
+DESCRIPTION = "Official SDK built using crosstool-ng, distributed by the \
+Zephyr project"
+COMPATIBLE_HOST = "(x86_64|aarch64).*-linux"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+INHIBIT_DEFAULT_DEPS = "1"
+# CMake is required by the setup script
+DEPENDS += "cmake"
+
+SDK_ARCHIVE = "zephyr-sdk-${PV}_linux-${BUILD_ARCH}.tar.xz"
+SDK_NAME = "${BUILD_ARCH}"
+SRC_URI = "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${PV}/${SDK_ARCHIVE};subdir=${S};name=${SDK_NAME}"
+
+SRC_URI[x86_64.sha256sum] = "cb4e4012751e4526aaf1ec1e8ab9b4ded5681e2e01711b64f7a1b519ff7dbc6a"
+SRC_URI[aarch64.sha256sum] = "83782b4cf595bb3da8a6c7c1ade01eed00ad03f8ba0c72da6680693192b3668d"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+ZEPHYR_SDK_DIR = "${prefix}/zephyr-sdk"
+
+do_install() {
+    install -d ${D}${prefix}
+    cp -r ${S}/zephyr-sdk-${PV} ${D}${ZEPHYR_SDK_DIR}
+
+    # Install host tools
+    ${D}${ZEPHYR_SDK_DIR}/setup.sh -h
+}
+
+SYSROOT_DIRS += "${ZEPHYR_SDK_DIR}"
+INHIBIT_SYSROOT_STRIP = "1"
+BBCLASSEXTEND = "native"

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/amd-zephyr-kernel-src.inc
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/amd-zephyr-kernel-src.inc
@@ -1,0 +1,4 @@
+SRC_URI_ZEPHYR = "git://github.com/Xilinx/zephyr-amd.git;protocol=https"
+ZEPHYR_BRANCH = "xlnx_rel_v2025.1"
+SRCREV_default = "7684201fbf0b9183b660a61170c600f8b6e50b44"
+PV = "amd-${PREFERRED_VERSION_zephyr-kernel}+git${SRCPV}"

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/files/0001-v3.7.0-x86-fix-efi-binary-generation-issue-in-cross-compila.patch
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/files/0001-v3.7.0-x86-fix-efi-binary-generation-issue-in-cross-compila.patch
@@ -1,0 +1,106 @@
+From 90d5e7c9c6037a030d5c0bfa4ae298da66eaf35e Mon Sep 17 00:00:00 2001
+From: Naveen Saini <naveen.kumar.saini@intel.com>
+Date: Thu, 12 Sep 2024 21:05:09 +0800
+Subject: [PATCH] x86: fix efi binary generation issue in cross compilation env
+
+Set root directory for headers.
+
+Upstream-Status: Inappropriate [Cross-compilation specific]
+
+Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
+---
+ arch/x86/zefi/zefi.py                                       | 5 ++++-
+ boards/intel/adl/CMakeLists.txt                             | 1 +
+ boards/intel/ehl/CMakeLists.txt                             | 1 +
+ boards/intel/rpl/CMakeLists.txt                             | 1 +
+ boards/up-bridge-the-gap/up_squared/CMakeLists.txt          | 1 +
+ boards/up-bridge-the-gap/up_squared_pro_7000/CMakeLists.txt | 1 +
+ 6 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/arch/x86/zefi/zefi.py b/arch/x86/zefi/zefi.py
+index 99c188ecd08..1cd86a21cd4 100755
+--- a/arch/x86/zefi/zefi.py
++++ b/arch/x86/zefi/zefi.py
+@@ -109,8 +109,10 @@ def build_elf(elf_file, include_dirs):
+     includes = []
+     for include_dir in include_dirs:
+         includes.extend(["-I", include_dir])
++    #  Pass --sysroot path for cross compilation
++    sysrootarg = "--sysroot=" + args.sysroot
+     cmd = ([args.compiler, "-shared", "-Wall", "-Werror", "-I."] + includes +
+-           ["-fno-stack-protector", "-fpic", "-mno-red-zone", "-fshort-wchar",
++           ["-fno-stack-protector", "-fpic", "-mno-red-zone", "-fshort-wchar", sysrootarg,
+             "-Wl,-nostdlib", "-T", ldscript, "-o", "zefi.elf", cfile])
+     verbose(" ".join(cmd))
+     subprocess.run(cmd, check = True)
+@@ -150,6 +152,7 @@ def parse_args():
+     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+     parser.add_argument("-i", "--includes", required=True, nargs="+",
+                         help="Zephyr base include directories")
++    parser.add_argument("-s", "--sysroot", required=True, help="Cross compilation --sysroot=path")
+ 
+     return parser.parse_args()
+ 
+diff --git a/boards/intel/adl/CMakeLists.txt b/boards/intel/adl/CMakeLists.txt
+index 36ddcdf9d13..4cb244a777d 100644
+--- a/boards/intel/adl/CMakeLists.txt
++++ b/boards/intel/adl/CMakeLists.txt
+@@ -8,6 +8,7 @@ set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+   -o ${CMAKE_OBJCOPY}
+   -i ${ZEPHYR_BASE}/include
+   -f ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.elf
++  -s ${SYSROOT_DIR}
+   $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+ )
+diff --git a/boards/intel/ehl/CMakeLists.txt b/boards/intel/ehl/CMakeLists.txt
+index 36ddcdf9d13..4cb244a777d 100644
+--- a/boards/intel/ehl/CMakeLists.txt
++++ b/boards/intel/ehl/CMakeLists.txt
+@@ -8,6 +8,7 @@ set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+   -o ${CMAKE_OBJCOPY}
+   -i ${ZEPHYR_BASE}/include
+   -f ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.elf
++  -s ${SYSROOT_DIR}
+   $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+ )
+diff --git a/boards/intel/rpl/CMakeLists.txt b/boards/intel/rpl/CMakeLists.txt
+index 36ddcdf9d13..4cb244a777d 100644
+--- a/boards/intel/rpl/CMakeLists.txt
++++ b/boards/intel/rpl/CMakeLists.txt
+@@ -8,6 +8,7 @@ set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+   -o ${CMAKE_OBJCOPY}
+   -i ${ZEPHYR_BASE}/include
+   -f ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.elf
++  -s ${SYSROOT_DIR}
+   $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+ )
+diff --git a/boards/up-bridge-the-gap/up_squared/CMakeLists.txt b/boards/up-bridge-the-gap/up_squared/CMakeLists.txt
+index ddfd93807ff..8dfe7aa9cec 100644
+--- a/boards/up-bridge-the-gap/up_squared/CMakeLists.txt
++++ b/boards/up-bridge-the-gap/up_squared/CMakeLists.txt
+@@ -11,6 +11,7 @@ set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+   -o ${CMAKE_OBJCOPY}
+   -i ${ZEPHYR_BASE}/include
+   -f ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.elf
++  -s ${SYSROOT_DIR}
+   $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+ )
+diff --git a/boards/up-bridge-the-gap/up_squared_pro_7000/CMakeLists.txt b/boards/up-bridge-the-gap/up_squared_pro_7000/CMakeLists.txt
+index 36ddcdf9d13..4cb244a777d 100644
+--- a/boards/up-bridge-the-gap/up_squared_pro_7000/CMakeLists.txt
++++ b/boards/up-bridge-the-gap/up_squared_pro_7000/CMakeLists.txt
+@@ -8,6 +8,7 @@ set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
+   -o ${CMAKE_OBJCOPY}
+   -i ${ZEPHYR_BASE}/include
+   -f ${PROJECT_BINARY_DIR}/${CONFIG_KERNEL_BIN_NAME}.elf
++  -s ${SYSROOT_DIR}
+   $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--verbose>
+   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+ )
+-- 
+2.37.3
+

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-helloworld.bbappend
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-helloworld.bbappend
@@ -1,0 +1,3 @@
+# To use SRC_URI_ZEPHYR pointing to zephyr-amd github tree instead of upstream
+# zephyr tree we need add amd-zephyr-kernel-src include file.
+require amd-zephyr-kernel-src.inc

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-helloworld.bbappend
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-helloworld.bbappend
@@ -1,3 +1,5 @@
+inherit amd-zephyr-sdt
+
 # To use SRC_URI_ZEPHYR pointing to zephyr-amd github tree instead of upstream
 # zephyr tree we need add amd-zephyr-kernel-src include file.
 require amd-zephyr-kernel-src.inc

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-kernel-src-3.7.0.inc
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-kernel-src-3.7.0.inc
@@ -1,0 +1,275 @@
+# Auto-generated from zephyr-kernel-src.inc.jinja
+
+SRCREV_FORMAT = "default"
+
+SRCREV_default = "36940db938a8f4a1e919496793ed439850a221c2"
+SRCREV_acpica = "8d24867bc9c9d81c81eeac59391cda59333affd4"
+SRCREV_bsim = "9351ae1ad44864a49c351f9704f65f43046abeb0"
+SRCREV_babblesim_base = "4bd907be0b2abec3b31a23fd8ca98db2a07209d2"
+SRCREV_babblesim_ext_2G4_libPhyComv1 = "93f5eba512c438b0c9ebc1b1a947517c865b3643"
+SRCREV_babblesim_ext_2G4_phy_v1 = "04eeb3c3794444122fbeeb3715f4233b0b50cfbb"
+SRCREV_babblesim_ext_2G4_channel_NtNcable = "20a38c997f507b0aa53817aab3d73a462fff7af1"
+SRCREV_babblesim_ext_2G4_channel_multiatt = "bde72a57384dde7a4310bcf3843469401be93074"
+SRCREV_babblesim_ext_2G4_modem_magic = "edfcda2d3937a74be0a59d6cd47e0f50183453da"
+SRCREV_babblesim_ext_2G4_modem_BLE_simple = "a38d2d24b04a6f970a225d1316047256ebf5a539"
+SRCREV_babblesim_ext_2G4_device_burst_interferer = "5b5339351d6e6a2368c686c734dc8b2fc65698fc"
+SRCREV_babblesim_ext_2G4_device_WLAN_actmod = "9cb6d8e72695f6b785e57443f0629a18069d6ce4"
+SRCREV_babblesim_ext_2G4_device_playback = "abb48cd71ddd4e2a9022f4bf49b2712524c483e8"
+SRCREV_babblesim_ext_libCryptov1 = "eed6d7038e839153e340bd333bc43541cb90ba64"
+SRCREV_cmsis = "4b96cbb174678dcd3ca86e11e1f24bc5f8726da0"
+SRCREV_cmsis-dsp = "6489e771e9c405f1763b52d64a3f17a1ec488ace"
+SRCREV_cmsis-nn = "ea987c1ca661be723de83bd159aed815d6cbd430"
+SRCREV_edtt = "8d7b543d4d2f2be0f78481e4e1d8d73a88024803"
+SRCREV_fatfs = "427159bf95ea49b7680facffaa29ad506b42709b"
+SRCREV_hal_adi = "dee9a7b1eff13a9da0560daf8842d61657f9d61e"
+SRCREV_hal_altera = "4fe4df959d4593ce66e676aeba0b57f546dba0fe"
+SRCREV_hal_ambiq = "e25327f026df1ee08f1bf01a4bbfeb5e5f4026f1"
+SRCREV_hal_atmel = "56d60ebc909ad065bf6554cee73487969857614b"
+SRCREV_hal_espressif = "87e7902d7184a8280b4d13bce79801a723f4ddd8"
+SRCREV_hal_ethos_u = "8e2cf756b474eff9a32a9bdf1775d9620f1eadcf"
+SRCREV_hal_gigadevice = "2994b7dde8b0b0fa9b9c0ccb13474b6a486cddc3"
+SRCREV_hal_infineon = "f25734a72c585f6675e8254a382e80e78a3cd03a"
+SRCREV_hal_intel = "0905a528623de56b1bedf817536321bcdbc0efae"
+SRCREV_hal_microchip = "71eba057c0cb7fc11b6f33eb40a82f1ebe2c571c"
+SRCREV_hal_nordic = "ab5cb2e2faeb1edfad7a25286dcb513929ae55da"
+SRCREV_hal_nuvoton = "466c3eed9c98453fb23953bf0e0427fea01924be"
+SRCREV_hal_nxp = "862e001504bd6e0a4feade6a718e9f973116849c"
+SRCREV_hal_openisa = "eabd530a64d71de91d907bad257cd61aacf607bc"
+SRCREV_hal_quicklogic = "bad894440fe72c814864798c8e3a76d13edffb6c"
+SRCREV_hal_renesas = "af77d7cdfeeff290593e7e99f54f0c1e2a3f91e6"
+SRCREV_hal_rpi_pico = "fba7162cc7bee06d0149622bbcaac4e41062d368"
+SRCREV_hal_silabs = "a09dd1b82b24aa3060e162c0dfa40026c0dba450"
+SRCREV_hal_st = "b77157f6bc4395e398d90ab02a7d2cbc01ab2ce7"
+SRCREV_hal_stm32 = "f1317150eac951fdd8259337a47cbbc4c2e6d335"
+SRCREV_hal_telink = "4226c7fc17d5a34e557d026d428fc766191a0800"
+SRCREV_hal_ti = "b85f86e51fc4d47c4c383d320d64d52d4d371ae4"
+SRCREV_hal_wurthelektronik = "e5bcb2eac1bb9639ce13b4dafc78eb254e014342"
+SRCREV_hal_xtensa = "a2d658525b16c57bea8dd565f5bd5167e4b9f1ee"
+SRCREV_hostap = "a90df86d7c596a5367ff70c2b50c7f599e6636f3"
+SRCREV_libmetal = "a6851ba6dba8c9e87d00c42f171a822f7a29639b"
+SRCREV_liblc3 = "1a5938ebaca4f13fe79ce074f5dee079783aa29f"
+SRCREV_littlefs = "408c16a909dd6cf128874a76f21c793798c9e423"
+SRCREV_loramac-node = "fb00b383072518c918e2258b0916c996f2d4eebe"
+SRCREV_lvgl = "2b498e6f36d6b82ae1da12c8b7742e318624ecf5"
+SRCREV_mbedtls = "2f24831ee13d399ce019c4632b0bcd440a713f7c"
+SRCREV_mcuboot = "fb2cf0ec3da3687b93f28e556ab682bdd4b85223"
+SRCREV_mipi-sys-t = "71ace1f5caa03e56c8740a09863e685efb4b2360"
+SRCREV_net-tools = "7c7a856814d7f27509c8511fef14cec21f7d0c30"
+SRCREV_nrf_hw_models = "6c389b9b5fa0a079cd4502e69d375da4c0c289b7"
+SRCREV_open-amp = "76d2168bcdfcd23a9a7dce8c21f2083b90a1e60a"
+SRCREV_openthread = "3873c6fcd5a8a9dd01b71e8efe32ef5dc7923bb1"
+SRCREV_percepio = "a49e5f3947faad0dd654eddd5a750127fb81e50d"
+SRCREV_picolibc = "764ef4e401a8f4c6a86ab723533841f072885a5b"
+SRCREV_segger = "b011c45b585e097d95d9cf93edf4f2e01588d3cd"
+SRCREV_tinycrypt = "1012a3ebee18c15ede5efc8332ee2fc37817670f"
+SRCREV_trusted-firmware-m = "069455be098383bf96eab73e3ff8e0c66c60fa5a"
+SRCREV_trusted-firmware-a = "713ffbf96c5bcbdeab757423f10f73eb304eff07"
+SRCREV_uoscore-uedhoc = "84ef879a46d7bfd9a423fbfb502b04289861f9ea"
+SRCREV_zcbor = "75d088037eb237b18e7ec1f47c9ce494b9b95aab"
+
+SRC_URI_ZEPHYR ?= "git://github.com/zephyrproject-rtos/zephyr.git;protocol=https"
+SRC_URI_ZEPHYR_ACPICA ?= "git://github.com/zephyrproject-rtos/acpica;protocol=https"
+SRC_URI_ZEPHYR_BSIM ?= "git://github.com/zephyrproject-rtos/babblesim-manifest;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_BASE ?= "git://github.com/BabbleSim/base;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_LIBPHYCOMV1 ?= "git://github.com/BabbleSim/ext_2G4_libPhyComv1;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_PHY_V1 ?= "git://github.com/BabbleSim/ext_2G4_phy_v1;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_CHANNEL_NTNCABLE ?= "git://github.com/BabbleSim/ext_2G4_channel_NtNcable;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_CHANNEL_MULTIATT ?= "git://github.com/BabbleSim/ext_2G4_channel_multiatt;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_MODEM_MAGIC ?= "git://github.com/BabbleSim/ext_2G4_modem_magic;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_MODEM_BLE_SIMPLE ?= "git://github.com/BabbleSim/ext_2G4_modem_BLE_simple;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_DEVICE_BURST_INTERFERER ?= "git://github.com/BabbleSim/ext_2G4_device_burst_interferer;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_DEVICE_WLAN_ACTMOD ?= "git://github.com/BabbleSim/ext_2G4_device_WLAN_actmod;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_DEVICE_PLAYBACK ?= "git://github.com/BabbleSim/ext_2G4_device_playback;protocol=https"
+SRC_URI_ZEPHYR_BABBLESIM_EXT_LIBCRYPTOV1 ?= "git://github.com/BabbleSim/ext_libCryptov1;protocol=https"
+SRC_URI_ZEPHYR_CMSIS ?= "git://github.com/zephyrproject-rtos/cmsis;protocol=https"
+SRC_URI_ZEPHYR_CMSIS_DSP ?= "git://github.com/zephyrproject-rtos/cmsis-dsp;protocol=https"
+SRC_URI_ZEPHYR_CMSIS_NN ?= "git://github.com/zephyrproject-rtos/cmsis-nn;protocol=https"
+SRC_URI_ZEPHYR_EDTT ?= "git://github.com/zephyrproject-rtos/edtt;protocol=https"
+SRC_URI_ZEPHYR_FATFS ?= "git://github.com/zephyrproject-rtos/fatfs;protocol=https"
+SRC_URI_ZEPHYR_HAL_ADI ?= "git://github.com/zephyrproject-rtos/hal_adi;protocol=https"
+SRC_URI_ZEPHYR_HAL_ALTERA ?= "git://github.com/zephyrproject-rtos/hal_altera;protocol=https"
+SRC_URI_ZEPHYR_HAL_AMBIQ ?= "git://github.com/zephyrproject-rtos/hal_ambiq;protocol=https"
+SRC_URI_ZEPHYR_HAL_ATMEL ?= "git://github.com/zephyrproject-rtos/hal_atmel;protocol=https"
+SRC_URI_ZEPHYR_HAL_ESPRESSIF ?= "git://github.com/zephyrproject-rtos/hal_espressif;protocol=https"
+SRC_URI_ZEPHYR_HAL_ETHOS_U ?= "git://github.com/zephyrproject-rtos/hal_ethos_u;protocol=https"
+SRC_URI_ZEPHYR_HAL_GIGADEVICE ?= "git://github.com/zephyrproject-rtos/hal_gigadevice;protocol=https"
+SRC_URI_ZEPHYR_HAL_INFINEON ?= "git://github.com/zephyrproject-rtos/hal_infineon;protocol=https"
+SRC_URI_ZEPHYR_HAL_INTEL ?= "git://github.com/zephyrproject-rtos/hal_intel;protocol=https"
+SRC_URI_ZEPHYR_HAL_MICROCHIP ?= "git://github.com/zephyrproject-rtos/hal_microchip;protocol=https"
+SRC_URI_ZEPHYR_HAL_NORDIC ?= "git://github.com/zephyrproject-rtos/hal_nordic;protocol=https"
+SRC_URI_ZEPHYR_HAL_NUVOTON ?= "git://github.com/zephyrproject-rtos/hal_nuvoton;protocol=https"
+SRC_URI_ZEPHYR_HAL_NXP ?= "git://github.com/zephyrproject-rtos/hal_nxp;protocol=https"
+SRC_URI_ZEPHYR_HAL_OPENISA ?= "git://github.com/zephyrproject-rtos/hal_openisa;protocol=https"
+SRC_URI_ZEPHYR_HAL_QUICKLOGIC ?= "git://github.com/zephyrproject-rtos/hal_quicklogic;protocol=https"
+SRC_URI_ZEPHYR_HAL_RENESAS ?= "git://github.com/zephyrproject-rtos/hal_renesas;protocol=https"
+SRC_URI_ZEPHYR_HAL_RPI_PICO ?= "git://github.com/zephyrproject-rtos/hal_rpi_pico;protocol=https"
+SRC_URI_ZEPHYR_HAL_SILABS ?= "git://github.com/zephyrproject-rtos/hal_silabs;protocol=https"
+SRC_URI_ZEPHYR_HAL_ST ?= "git://github.com/zephyrproject-rtos/hal_st;protocol=https"
+SRC_URI_ZEPHYR_HAL_STM32 ?= "git://github.com/zephyrproject-rtos/hal_stm32;protocol=https"
+SRC_URI_ZEPHYR_HAL_TELINK ?= "git://github.com/zephyrproject-rtos/hal_telink;protocol=https"
+SRC_URI_ZEPHYR_HAL_TI ?= "git://github.com/zephyrproject-rtos/hal_ti;protocol=https"
+SRC_URI_ZEPHYR_HAL_WURTHELEKTRONIK ?= "git://github.com/zephyrproject-rtos/hal_wurthelektronik;protocol=https"
+SRC_URI_ZEPHYR_HAL_XTENSA ?= "git://github.com/zephyrproject-rtos/hal_xtensa;protocol=https"
+SRC_URI_ZEPHYR_HOSTAP ?= "git://github.com/zephyrproject-rtos/hostap;protocol=https"
+SRC_URI_ZEPHYR_LIBMETAL ?= "git://github.com/zephyrproject-rtos/libmetal;protocol=https"
+SRC_URI_ZEPHYR_LIBLC3 ?= "git://github.com/zephyrproject-rtos/liblc3;protocol=https"
+SRC_URI_ZEPHYR_LITTLEFS ?= "git://github.com/zephyrproject-rtos/littlefs;protocol=https"
+SRC_URI_ZEPHYR_LORAMAC_NODE ?= "git://github.com/zephyrproject-rtos/loramac-node;protocol=https"
+SRC_URI_ZEPHYR_LVGL ?= "git://github.com/zephyrproject-rtos/lvgl;protocol=https"
+SRC_URI_ZEPHYR_MBEDTLS ?= "git://github.com/zephyrproject-rtos/mbedtls;protocol=https"
+SRC_URI_ZEPHYR_MCUBOOT ?= "git://github.com/zephyrproject-rtos/mcuboot;protocol=https"
+SRC_URI_ZEPHYR_MIPI_SYS_T ?= "git://github.com/zephyrproject-rtos/mipi-sys-t;protocol=https"
+SRC_URI_ZEPHYR_NET_TOOLS ?= "git://github.com/zephyrproject-rtos/net-tools;protocol=https"
+SRC_URI_ZEPHYR_NRF_HW_MODELS ?= "git://github.com/zephyrproject-rtos/nrf_hw_models;protocol=https"
+SRC_URI_ZEPHYR_OPEN_AMP ?= "git://github.com/zephyrproject-rtos/open-amp;protocol=https"
+SRC_URI_ZEPHYR_OPENTHREAD ?= "git://github.com/zephyrproject-rtos/openthread;protocol=https"
+SRC_URI_ZEPHYR_PERCEPIO ?= "git://github.com/zephyrproject-rtos/percepio;protocol=https"
+SRC_URI_ZEPHYR_PICOLIBC ?= "git://github.com/zephyrproject-rtos/picolibc;protocol=https"
+SRC_URI_ZEPHYR_SEGGER ?= "git://github.com/zephyrproject-rtos/segger;protocol=https"
+SRC_URI_ZEPHYR_TINYCRYPT ?= "git://github.com/zephyrproject-rtos/tinycrypt;protocol=https"
+SRC_URI_ZEPHYR_TRUSTED_FIRMWARE_M ?= "git://github.com/zephyrproject-rtos/trusted-firmware-m;protocol=https"
+SRC_URI_ZEPHYR_TRUSTED_FIRMWARE_A ?= "git://github.com/zephyrproject-rtos/trusted-firmware-a;protocol=https"
+SRC_URI_ZEPHYR_UOSCORE_UEDHOC ?= "git://github.com/zephyrproject-rtos/uoscore-uedhoc;protocol=https"
+SRC_URI_ZEPHYR_ZCBOR ?= "git://github.com/zephyrproject-rtos/zcbor;protocol=https"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI_PATCHES ?= "\
+    file://0001-v3.7.0-x86-fix-efi-binary-generation-issue-in-cross-compila.patch;patchdir=zephyr \
+"
+
+SRC_URI = "\
+    ${SRC_URI_ZEPHYR};branch=${ZEPHYR_BRANCH};name=default;destsuffix=git/zephyr \
+    ${SRC_URI_ZEPHYR_ACPICA};name=acpica;nobranch=1;destsuffix=git/modules/lib/acpica \
+    ${SRC_URI_ZEPHYR_BSIM};name=bsim;nobranch=1;destsuffix=git/tools/bsim \
+    ${SRC_URI_ZEPHYR_BABBLESIM_BASE};name=babblesim_base;nobranch=1;destsuffix=git/tools/bsim/components \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_LIBPHYCOMV1};name=babblesim_ext_2G4_libPhyComv1;nobranch=1;destsuffix=git/tools/bsim/components/ext_2G4_libPhyComv1 \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_PHY_V1};name=babblesim_ext_2G4_phy_v1;nobranch=1;destsuffix=git/tools/bsim/components/ext_2G4_phy_v1 \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_CHANNEL_NTNCABLE};name=babblesim_ext_2G4_channel_NtNcable;nobranch=1;destsuffix=git/tools/bsim/components/ext_2G4_channel_NtNcable \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_CHANNEL_MULTIATT};name=babblesim_ext_2G4_channel_multiatt;nobranch=1;destsuffix=git/tools/bsim/components/ext_2G4_channel_multiatt \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_MODEM_MAGIC};name=babblesim_ext_2G4_modem_magic;nobranch=1;destsuffix=git/tools/bsim/components/ext_2G4_modem_magic \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_MODEM_BLE_SIMPLE};name=babblesim_ext_2G4_modem_BLE_simple;nobranch=1;destsuffix=git/tools/bsim/components/ext_2G4_modem_BLE_simple \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_DEVICE_BURST_INTERFERER};name=babblesim_ext_2G4_device_burst_interferer;nobranch=1;destsuffix=git/tools/bsim/components/ext_2G4_device_burst_interferer \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_DEVICE_WLAN_ACTMOD};name=babblesim_ext_2G4_device_WLAN_actmod;nobranch=1;destsuffix=git/tools/bsim/components/ext_2G4_device_WLAN_actmod \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_2G4_DEVICE_PLAYBACK};name=babblesim_ext_2G4_device_playback;nobranch=1;destsuffix=git/tools/bsim/components/ext_2G4_device_playback \
+    ${SRC_URI_ZEPHYR_BABBLESIM_EXT_LIBCRYPTOV1};name=babblesim_ext_libCryptov1;nobranch=1;destsuffix=git/tools/bsim/components/ext_libCryptov1 \
+    ${SRC_URI_ZEPHYR_CMSIS};name=cmsis;nobranch=1;destsuffix=git/modules/hal/cmsis \
+    ${SRC_URI_ZEPHYR_CMSIS_DSP};name=cmsis-dsp;nobranch=1;destsuffix=git/modules/lib/cmsis-dsp \
+    ${SRC_URI_ZEPHYR_CMSIS_NN};name=cmsis-nn;nobranch=1;destsuffix=git/modules/lib/cmsis-nn \
+    ${SRC_URI_ZEPHYR_EDTT};name=edtt;nobranch=1;destsuffix=git/tools/edtt \
+    ${SRC_URI_ZEPHYR_FATFS};name=fatfs;nobranch=1;destsuffix=git/modules/fs/fatfs \
+    ${SRC_URI_ZEPHYR_HAL_ADI};name=hal_adi;nobranch=1;destsuffix=git/modules/hal/adi \
+    ${SRC_URI_ZEPHYR_HAL_ALTERA};name=hal_altera;nobranch=1;destsuffix=git/modules/hal/altera \
+    ${SRC_URI_ZEPHYR_HAL_AMBIQ};name=hal_ambiq;nobranch=1;destsuffix=git/modules/hal/ambiq \
+    ${SRC_URI_ZEPHYR_HAL_ATMEL};name=hal_atmel;nobranch=1;destsuffix=git/modules/hal/atmel \
+    ${SRC_URI_ZEPHYR_HAL_ESPRESSIF};name=hal_espressif;nobranch=1;destsuffix=git/modules/hal/espressif \
+    ${SRC_URI_ZEPHYR_HAL_ETHOS_U};name=hal_ethos_u;nobranch=1;destsuffix=git/modules/hal/ethos_u \
+    ${SRC_URI_ZEPHYR_HAL_GIGADEVICE};name=hal_gigadevice;nobranch=1;destsuffix=git/modules/hal/gigadevice \
+    ${SRC_URI_ZEPHYR_HAL_INFINEON};name=hal_infineon;nobranch=1;destsuffix=git/modules/hal/infineon \
+    ${SRC_URI_ZEPHYR_HAL_INTEL};name=hal_intel;nobranch=1;destsuffix=git/modules/hal/intel \
+    ${SRC_URI_ZEPHYR_HAL_MICROCHIP};name=hal_microchip;nobranch=1;destsuffix=git/modules/hal/microchip \
+    ${SRC_URI_ZEPHYR_HAL_NORDIC};name=hal_nordic;nobranch=1;destsuffix=git/modules/hal/nordic \
+    ${SRC_URI_ZEPHYR_HAL_NUVOTON};name=hal_nuvoton;nobranch=1;destsuffix=git/modules/hal/nuvoton \
+    ${SRC_URI_ZEPHYR_HAL_NXP};name=hal_nxp;nobranch=1;destsuffix=git/modules/hal/nxp \
+    ${SRC_URI_ZEPHYR_HAL_OPENISA};name=hal_openisa;nobranch=1;destsuffix=git/modules/hal/openisa \
+    ${SRC_URI_ZEPHYR_HAL_QUICKLOGIC};name=hal_quicklogic;nobranch=1;destsuffix=git/modules/hal/quicklogic \
+    ${SRC_URI_ZEPHYR_HAL_RENESAS};name=hal_renesas;nobranch=1;destsuffix=git/modules/hal/renesas \
+    ${SRC_URI_ZEPHYR_HAL_RPI_PICO};name=hal_rpi_pico;nobranch=1;destsuffix=git/modules/hal/rpi_pico \
+    ${SRC_URI_ZEPHYR_HAL_SILABS};name=hal_silabs;nobranch=1;destsuffix=git/modules/hal/silabs \
+    ${SRC_URI_ZEPHYR_HAL_ST};name=hal_st;nobranch=1;destsuffix=git/modules/hal/st \
+    ${SRC_URI_ZEPHYR_HAL_STM32};name=hal_stm32;nobranch=1;destsuffix=git/modules/hal/stm32 \
+    ${SRC_URI_ZEPHYR_HAL_TELINK};name=hal_telink;nobranch=1;destsuffix=git/modules/hal/telink \
+    ${SRC_URI_ZEPHYR_HAL_TI};name=hal_ti;nobranch=1;destsuffix=git/modules/hal/ti \
+    ${SRC_URI_ZEPHYR_HAL_WURTHELEKTRONIK};name=hal_wurthelektronik;nobranch=1;destsuffix=git/modules/hal/wurthelektronik \
+    ${SRC_URI_ZEPHYR_HAL_XTENSA};name=hal_xtensa;nobranch=1;destsuffix=git/modules/hal/xtensa \
+    ${SRC_URI_ZEPHYR_HOSTAP};name=hostap;nobranch=1;destsuffix=git/modules/lib/hostap \
+    ${SRC_URI_ZEPHYR_LIBMETAL};name=libmetal;nobranch=1;destsuffix=git/modules/hal/libmetal \
+    ${SRC_URI_ZEPHYR_LIBLC3};name=liblc3;nobranch=1;destsuffix=git/modules/lib/liblc3 \
+    ${SRC_URI_ZEPHYR_LITTLEFS};name=littlefs;nobranch=1;destsuffix=git/modules/fs/littlefs \
+    ${SRC_URI_ZEPHYR_LORAMAC_NODE};name=loramac-node;nobranch=1;destsuffix=git/modules/lib/loramac-node \
+    ${SRC_URI_ZEPHYR_LVGL};name=lvgl;nobranch=1;destsuffix=git/modules/lib/gui/lvgl \
+    ${SRC_URI_ZEPHYR_MBEDTLS};name=mbedtls;nobranch=1;destsuffix=git/modules/crypto/mbedtls \
+    ${SRC_URI_ZEPHYR_MCUBOOT};name=mcuboot;nobranch=1;destsuffix=git/bootloader/mcuboot \
+    ${SRC_URI_ZEPHYR_MIPI_SYS_T};name=mipi-sys-t;nobranch=1;destsuffix=git/modules/debug/mipi-sys-t \
+    ${SRC_URI_ZEPHYR_NET_TOOLS};name=net-tools;nobranch=1;destsuffix=git/tools/net-tools \
+    ${SRC_URI_ZEPHYR_NRF_HW_MODELS};name=nrf_hw_models;nobranch=1;destsuffix=git/modules/bsim_hw_models/nrf_hw_models \
+    ${SRC_URI_ZEPHYR_OPEN_AMP};name=open-amp;nobranch=1;destsuffix=git/modules/lib/open-amp \
+    ${SRC_URI_ZEPHYR_OPENTHREAD};name=openthread;nobranch=1;destsuffix=git/modules/lib/openthread \
+    ${SRC_URI_ZEPHYR_PERCEPIO};name=percepio;nobranch=1;destsuffix=git/modules/debug/percepio \
+    ${SRC_URI_ZEPHYR_PICOLIBC};name=picolibc;nobranch=1;destsuffix=git/modules/lib/picolibc \
+    ${SRC_URI_ZEPHYR_SEGGER};name=segger;nobranch=1;destsuffix=git/modules/debug/segger \
+    ${SRC_URI_ZEPHYR_TINYCRYPT};name=tinycrypt;nobranch=1;destsuffix=git/modules/crypto/tinycrypt \
+    ${SRC_URI_ZEPHYR_TRUSTED_FIRMWARE_M};name=trusted-firmware-m;nobranch=1;destsuffix=git/modules/tee/tf-m/trusted-firmware-m \
+    ${SRC_URI_ZEPHYR_TRUSTED_FIRMWARE_A};name=trusted-firmware-a;nobranch=1;destsuffix=git/modules/tee/tf-a/trusted-firmware-a \
+    ${SRC_URI_ZEPHYR_UOSCORE_UEDHOC};name=uoscore-uedhoc;nobranch=1;destsuffix=git/modules/lib/uoscore-uedhoc \
+    ${SRC_URI_ZEPHYR_ZCBOR};name=zcbor;nobranch=1;destsuffix=git/modules/lib/zcbor \
+    ${SRC_URI_PATCHES} \
+"
+
+ZEPHYR_MODULES = "\
+${S}/modules/lib/acpica\;\
+${S}/tools/bsim\;\
+${S}/tools/bsim/components\;\
+${S}/tools/bsim/components/ext_2G4_libPhyComv1\;\
+${S}/tools/bsim/components/ext_2G4_phy_v1\;\
+${S}/tools/bsim/components/ext_2G4_channel_NtNcable\;\
+${S}/tools/bsim/components/ext_2G4_channel_multiatt\;\
+${S}/tools/bsim/components/ext_2G4_modem_magic\;\
+${S}/tools/bsim/components/ext_2G4_modem_BLE_simple\;\
+${S}/tools/bsim/components/ext_2G4_device_burst_interferer\;\
+${S}/tools/bsim/components/ext_2G4_device_WLAN_actmod\;\
+${S}/tools/bsim/components/ext_2G4_device_playback\;\
+${S}/tools/bsim/components/ext_libCryptov1\;\
+${S}/modules/hal/cmsis\;\
+${S}/modules/lib/cmsis-dsp\;\
+${S}/modules/lib/cmsis-nn\;\
+${S}/tools/edtt\;\
+${S}/modules/fs/fatfs\;\
+${S}/modules/hal/adi\;\
+${S}/modules/hal/altera\;\
+${S}/modules/hal/ambiq\;\
+${S}/modules/hal/atmel\;\
+${S}/modules/hal/espressif\;\
+${S}/modules/hal/ethos_u\;\
+${S}/modules/hal/gigadevice\;\
+${S}/modules/hal/infineon\;\
+${S}/modules/hal/intel\;\
+${S}/modules/hal/microchip\;\
+${S}/modules/hal/nordic\;\
+${S}/modules/hal/nuvoton\;\
+${S}/modules/hal/nxp\;\
+${S}/modules/hal/openisa\;\
+${S}/modules/hal/quicklogic\;\
+${S}/modules/hal/renesas\;\
+${S}/modules/hal/rpi_pico\;\
+${S}/modules/hal/silabs\;\
+${S}/modules/hal/st\;\
+${S}/modules/hal/stm32\;\
+${S}/modules/hal/telink\;\
+${S}/modules/hal/ti\;\
+${S}/modules/hal/wurthelektronik\;\
+${S}/modules/hal/xtensa\;\
+${S}/modules/lib/hostap\;\
+${S}/modules/hal/libmetal\;\
+${S}/modules/lib/liblc3\;\
+${S}/modules/fs/littlefs\;\
+${S}/modules/lib/loramac-node\;\
+${S}/modules/lib/gui/lvgl\;\
+${S}/modules/crypto/mbedtls\;\
+${S}/bootloader/mcuboot\;\
+${S}/modules/debug/mipi-sys-t\;\
+${S}/tools/net-tools\;\
+${S}/modules/bsim_hw_models/nrf_hw_models\;\
+${S}/modules/lib/open-amp\;\
+${S}/modules/lib/openthread\;\
+${S}/modules/debug/percepio\;\
+${S}/modules/lib/picolibc\;\
+${S}/modules/debug/segger\;\
+${S}/modules/crypto/tinycrypt\;\
+${S}/modules/tee/tf-m/trusted-firmware-m\;\
+${S}/modules/tee/tf-a/trusted-firmware-a\;\
+${S}/modules/lib/uoscore-uedhoc\;\
+${S}/modules/lib/zcbor\;\
+"
+
+ZEPHYR_BRANCH = "v3.7-branch"
+PV = "3.7.0+git${SRCPV}"

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-kernel-src.bbappend
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-kernel-src.bbappend
@@ -1,0 +1,3 @@
+# To use SRC_URI_ZEPHYR pointing to zephyr-amd github tree instead of upstream
+# zephyr tree we need add amd-zephyr-kernel-src include file.
+require amd-zephyr-kernel-src.inc

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-philosophers.bbappend
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-philosophers.bbappend
@@ -1,0 +1,3 @@
+# To use SRC_URI_ZEPHYR pointing to zephyr-amd github tree instead of upstream
+# zephyr tree we need add amd-zephyr-kernel-src include file.
+require amd-zephyr-kernel-src.inc

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-philosophers.bbappend
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-philosophers.bbappend
@@ -1,3 +1,5 @@
+inherit amd-zephyr-sdt
+
 # To use SRC_URI_ZEPHYR pointing to zephyr-amd github tree instead of upstream
 # zephyr tree we need add amd-zephyr-kernel-src include file.
 require amd-zephyr-kernel-src.inc

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-synchronization.bbappend
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-synchronization.bbappend
@@ -1,0 +1,3 @@
+# To use SRC_URI_ZEPHYR pointing to zephyr-amd github tree instead of upstream
+# zephyr tree we need add amd-zephyr-kernel-src include file.
+require amd-zephyr-kernel-src.inc

--- a/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-synchronization.bbappend
+++ b/meta-amd-zephyr/recipes-kernel/zephyr-kernel/zephyr-synchronization.bbappend
@@ -1,3 +1,5 @@
+inherit amd-zephyr-sdt
+
 # To use SRC_URI_ZEPHYR pointing to zephyr-amd github tree instead of upstream
 # zephyr tree we need add amd-zephyr-kernel-src include file.
 require amd-zephyr-kernel-src.inc

--- a/meta-xilinx-core/conf/layer.conf
+++ b/meta-xilinx-core/conf/layer.conf
@@ -62,9 +62,10 @@ PREFERRED_PROVIDER_nativesdk-qemu ?= "nativesdk-${DEFAULT_XILINX_QEMU}"
 XILINX_ATF_VERSION[v2023.1] = "2.8-xilinx-v2023.1%"
 XILINX_ATF_VERSION[v2023.2] = "2.8-xilinx-v2023.2%"
 XILINX_ATF_VERSION[v2024.1] = "2.10-xilinx-v2024.1%"
-XILINX_ATF_VERSION[v2024.2] = "2.10-xilinx-v2024.2%"
-XILINX_ATF_VERSION[v2025.1] = "2.12-xilinx-v2025.1%"
+XILINX_ATF_VERSION[v2024.2] = "2.10.0-xilinx-v2024.2%"
+XILINX_ATF_VERSION[v2025.1] = "2.12.0-xilinx-v2025.1%"
 PREFERRED_VERSION_virtual/arm-trusted-firmware ?= "${@d.getVarFlag('XILINX_ATF_VERSION', d.getVar('XILINX_RELEASE_VERSION')) or 'undefined'}"
+PREFERRED_VERSION_trusted-firmware-a ?= "${@d.getVarFlag('XILINX_ATF_VERSION', d.getVar('XILINX_RELEASE_VERSION')) or 'undefined'}"
 
 # The name of the software has changed to match upstream ARM
 XILINX_ATF_PROVIDERS[v2024.2] = "trusted-firmware-a"


### PR DESCRIPTION
When building with `XILINX_RELEASE_VERSION` set to `v2024.2`, a wrong version of the `trusted-firmware-a` component is used (the latest `v2025.1`). There are two reasons for this:

* The `XILINX_ATF_VERSION` string contains only major and minor SemVer numbers. The filenames in `meta-xilinx-core/recipes-bsp/trusted-firmware-a` also have the patch component.
* I'm not sure why, but setting the `PREFERRED_VERSION` for `virtual/arm-trusted-firmware` has no effect. `trusted-firmware-a` is only built with version `2024.2` when it is explicitly specified without the virtual indirect.