### PR TITLE
WIP: capture gcc-14 fixes for binutils

### DIFF
--- a/meta-microblaze/recipes-devtools/binutils/binutils-microblaze.inc
+++ b/meta-microblaze/recipes-devtools/binutils/binutils-microblaze.inc
@@ -62,4 +62,9 @@ SRC_URI += " \
     file://0054-Roll-back-an-improvement-which-inlines-target_gdbarc.patch \
     file://0055-fix-microblaze-linux-nat.patch \
     file://0056-Microblaze_Fix_regression_introduced_during_2024.2.patch \
+    file://0057-elf64-microblaze-correct-type-signature-mismatches.patch \
+    file://0058-microblaze64-use-elf_dyn_relocs-rather-than-elf64_mb.patch \
+    file://0059-microblaze-Correct-missing-return-type-in-function-s.patch \
+    file://0060-microblaze-correct-incompatible-type-cast-gcc-14.patch \
+    file://0061-RFC-work-around-compiler-errors-that-certainly-deser.patch \
 "

--- a/meta-microblaze/recipes-devtools/binutils/binutils/0057-elf64-microblaze-correct-type-signature-mismatches.patch
+++ b/meta-microblaze/recipes-devtools/binutils/binutils/0057-elf64-microblaze-correct-type-signature-mismatches.patch
@@ -1,0 +1,89 @@
+From 48d00ad4f63c80bdf83a39f662ce2243feede783 Mon Sep 17 00:00:00 2001
+From: Graeme Smecher <gsmecher@t0.technology>
+Date: Wed, 16 Jul 2025 10:04:00 -0700
+Subject: [PATCH 57/61] elf64-microblaze: correct type signature mismatches
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The incorrect pointer type is promoted to an error by gcc-14, and
+corrects the build errors shown at the bottom.
+
+The use of "struct bfd_link_info" rather than "obfd" dates back to 2016:
+
+    https://ecos.sourceware.org/ml/binutils/2016-10/msg00052.html
+
+...so I do not believe this is tied to a recent binutils release.
+
+    libtool: compile:  gcc [...] -c ../../bfd/elf64-microblaze.c -o elf64-microblaze.o
+    ../../bfd/elf64-microblaze.c: In function ‘microblaze_elf_merge_private_bfd_data’:
+    ../../bfd/elf64-microblaze.c:1815:49: error: passing argument 2 of ‘_bfd_generic_verify_endian_match’ from incompatible pointer type [-Wincompatible-pointer-types]
+     1815 |   if (! _bfd_generic_verify_endian_match (ibfd, obfd))
+          |                                                 ^~~~
+          |                                                 |
+          |                                                 bfd *
+    In file included from ../../bfd/elf64-microblaze.c:26:
+    ../../bfd/libbfd.h:1037:38: note: expected ‘struct bfd_link_info *’ but argument is of type ‘bfd *’
+     1037 |    (bfd *ibfd, struct bfd_link_info *info) ATTRIBUTE_HIDDEN;
+          |                ~~~~~~~~~~~~~~~~~~~~~~^~~~
+    ./elf64-target.h: At top level:
+    ../../bfd/elf64-microblaze.c:3806:49: error: initialization of ‘_Bool (*)(bfd *, struct bfd_link_info *)’ from incompatible pointer type ‘_Bool (*)(bfd *, bfd *)’ [-Wincompatible-pointer-types]
+     3806 | #define bfd_elf64_bfd_merge_private_bfd_data    microblaze_elf_merge_private_bfd_data
+          |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ./bfd.h:7702:3: note: in expansion of macro ‘bfd_elf64_bfd_merge_private_bfd_data’
+     7702 |   NAME##_bfd_merge_private_bfd_data, \
+          |   ^~~~
+    ./elf64-target.h:1061:3: note: in expansion of macro ‘BFD_JUMP_TABLE_COPY’
+     1061 |   BFD_JUMP_TABLE_COPY (bfd_elf64),
+          |   ^~~~~~~~~~~~~~~~~~~
+    ../../bfd/elf64-microblaze.c:3806:49: note: (near initialization for ‘microblaze_elf64_vec._bfd_merge_private_bfd_data’)
+     3806 | #define bfd_elf64_bfd_merge_private_bfd_data    microblaze_elf_merge_private_bfd_data
+          |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ./bfd.h:7702:3: note: in expansion of macro ‘bfd_elf64_bfd_merge_private_bfd_data’
+     7702 |   NAME##_bfd_merge_private_bfd_data, \
+          |   ^~~~
+    ./elf64-target.h:1061:3: note: in expansion of macro ‘BFD_JUMP_TABLE_COPY’
+     1061 |   BFD_JUMP_TABLE_COPY (bfd_elf64),
+          |   ^~~~~~~~~~~~~~~~~~~
+    ../../bfd/elf64-microblaze.c:3806:49: error: initialization of ‘_Bool (*)(bfd *, struct bfd_link_info *)’ from incompatible pointer type ‘_Bool (*)(bfd *, bfd *)’ [-Wincompatible-pointer-types]
+     3806 | #define bfd_elf64_bfd_merge_private_bfd_data    microblaze_elf_merge_private_bfd_data
+          |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ./bfd.h:7702:3: note: in expansion of macro ‘bfd_elf64_bfd_merge_private_bfd_data’
+     7702 |   NAME##_bfd_merge_private_bfd_data, \
+          |   ^~~~
+    ./elf64-target.h:1166:3: note: in expansion of macro ‘BFD_JUMP_TABLE_COPY’
+     1166 |   BFD_JUMP_TABLE_COPY (bfd_elf64),
+          |   ^~~~~~~~~~~~~~~~~~~
+    ../../bfd/elf64-microblaze.c:3806:49: note: (near initialization for ‘microblaze_elf64_le_vec._bfd_merge_private_bfd_data’)
+     3806 | #define bfd_elf64_bfd_merge_private_bfd_data    microblaze_elf_merge_private_bfd_data
+          |                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ./bfd.h:7702:3: note: in expansion of macro ‘bfd_elf64_bfd_merge_private_bfd_data’
+     7702 |   NAME##_bfd_merge_private_bfd_data, \
+          |   ^~~~
+    ./elf64-target.h:1166:3: note: in expansion of macro ‘BFD_JUMP_TABLE_COPY’
+     1166 |   BFD_JUMP_TABLE_COPY (bfd_elf64),
+          |   ^~~~~~~~~~~~~~~~~~~
+---
+ bfd/elf64-microblaze.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bfd/elf64-microblaze.c b/bfd/elf64-microblaze.c
+index 9f542f55..3b12802a 100755
+--- a/bfd/elf64-microblaze.c
++++ b/bfd/elf64-microblaze.c
+@@ -1809,10 +1809,10 @@ microblaze_elf_relocate_section (bfd *output_bfd,
+ 
+    Note: We only use this hook to catch endian mismatches.  */
+ static bool
+-microblaze_elf_merge_private_bfd_data (bfd * ibfd, bfd * obfd)
++microblaze_elf_merge_private_bfd_data (bfd * ibfd, struct bfd_link_info *info)
+ {
+   /* Check if we have the same endianess.  */
+-  if (! _bfd_generic_verify_endian_match (ibfd, obfd))
++  if (! _bfd_generic_verify_endian_match (ibfd, info))
+     return false;
+ 
+   return true;
+-- 
+2.47.2
+

--- a/meta-microblaze/recipes-devtools/binutils/binutils/0058-microblaze64-use-elf_dyn_relocs-rather-than-elf64_mb.patch
+++ b/meta-microblaze/recipes-devtools/binutils/binutils/0058-microblaze64-use-elf_dyn_relocs-rather-than-elf64_mb.patch
@@ -1,0 +1,172 @@
+From 4695a57f49849604a763f797b754139b2a2ec86b Mon Sep 17 00:00:00 2001
+From: Graeme Smecher <gsmecher@t0.technology>
+Date: Wed, 16 Jul 2025 10:17:21 -0700
+Subject: [PATCH 58/61] microblaze64: use elf_dyn_relocs rather than
+ elf64_mb_dyn_relocs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The two structures are identical, and before this patch, building on
+gcc-14 fails as follows:
+
+    gcc [...] -c ../../bfd/elf64-microblaze.c -o elf64-microblaze.o
+    ../../bfd/elf64-microblaze.c: In function ‘microblaze_elf_check_relocs’:
+    ../../bfd/elf64-microblaze.c:2821:24: error: assignment to ‘struct elf64_mb_dyn_relocs **’ from incompatible pointer type ‘struct elf_dyn_relocs **’ [-Wincompatible-pointer-types]
+     2821 |                   head = &h->dyn_relocs;
+          |                        ^
+    ../../bfd/elf64-microblaze.c: In function ‘microblaze_elf_adjust_dynamic_symbol’:
+    ../../bfd/elf64-microblaze.c:2959:17: warning: unused variable ‘srel’ [-Wunused-variable]
+     2959 |   asection *s, *srel;
+          |                 ^~~~
+    ../../bfd/elf64-microblaze.c: In function ‘allocate_dynrelocs’:
+    ../../bfd/elf64-microblaze.c:3283:10: error: assignment to ‘struct elf64_mb_dyn_relocs *’ from incompatible pointer type ‘struct elf_dyn_relocs *’ [-Wincompatible-pointer-types]
+     3283 |   for (p = h->dyn_relocs; p != NULL; p = p->next)
+          |          ^
+    ../../bfd/elf64-microblaze.c: In function ‘microblaze_elf_size_dynamic_sections’:
+    ../../bfd/elf64-microblaze.c:3328:18: error: assignment to ‘struct elf_dyn_relocs *’ from incompatible pointer type ‘struct elf64_mb_dyn_relocs *’ [-Wincompatible-pointer-types]
+     3328 |           for (p = ((struct elf64_mb_dyn_relocs *)
+          |                  ^
+    ../../bfd/elf64-microblaze.c: At top level:
+    ../../bfd/elf64-microblaze.c:2577:1: warning: ‘microblaze_elf_gc_sweep_hook’ defined but not used [-Wunused-function]
+     2577 | microblaze_elf_gc_sweep_hook (bfd * abfd ATTRIBUTE_UNUSED,
+          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Harmonization of the dyn_relocs structs appears to date back to 2020:
+
+    https://lists.gnu.org/archive/html/bug-binutils/2020-06/msg00023.html
+
+I believe this patch follows convention, but if the local struct
+definition is desirable, it's probably just a matter of a few missing
+casts.
+---
+ bfd/elf64-microblaze.c | 44 ++++++++++++------------------------------
+ 1 file changed, 12 insertions(+), 32 deletions(-)
+
+diff --git a/bfd/elf64-microblaze.c b/bfd/elf64-microblaze.c
+index 3b12802a..fe1df793 100755
+--- a/bfd/elf64-microblaze.c
++++ b/bfd/elf64-microblaze.c
+@@ -807,26 +807,6 @@ microblaze_elf_is_local_label_name (bfd *abfd, const char *name)
+   return _bfd_elf_is_local_label_name (abfd, name);
+ }
+ 
+-/* The microblaze linker (like many others) needs to keep track of
+-   the number of relocs that it decides to copy as dynamic relocs in
+-   check_relocs for each symbol. This is so that it can later discard
+-   them if they are found to be unnecessary.  We store the information
+-   in a field extending the regular ELF linker hash table.  */
+-
+-struct elf64_mb_dyn_relocs
+-{
+-  struct elf64_mb_dyn_relocs *next;
+-
+-  /* The input section of the reloc.  */
+-  asection *sec;
+-
+-  /* Total number of relocs copied for the input section.  */
+-  bfd_size_type count;
+-
+-  /* Number of pc-relative relocs copied for the input section.  */
+-  bfd_size_type pc_count;
+-};
+-
+ /* ELF linker hash entry.  */
+ 
+ struct elf64_mb_link_hash_entry
+@@ -834,7 +814,7 @@ struct elf64_mb_link_hash_entry
+   struct elf_link_hash_entry elf;
+ 
+   /* Track dynamic relocs copied for this symbol.  */
+-  struct elf64_mb_dyn_relocs *dyn_relocs;
++  struct elf_dyn_relocs *dyn_relocs;
+ 
+   /* TLS Reference Types for the symbol; Updated by check_relocs */
+ #define TLS_GD     1  /* GD reloc. */
+@@ -2794,8 +2774,8 @@ microblaze_elf_check_relocs (bfd * abfd,
+                     && (h->root.type == bfd_link_hash_defweak
+                         || !h->def_regular)))
+               {
+-                struct elf64_mb_dyn_relocs *p;
+-                struct elf64_mb_dyn_relocs **head;
++                struct elf_dyn_relocs *p;
++                struct elf_dyn_relocs **head;
+ 
+                 /* When creating a shared object, we must copy these
+                    relocs into the output file.  We create a reloc
+@@ -2839,14 +2819,14 @@ microblaze_elf_check_relocs (bfd * abfd,
+ 		      return false;
+ 
+ 		    vpp = &elf_section_data (s)->local_dynrel;
+-		    head = (struct elf64_mb_dyn_relocs **) vpp;
++		    head = (struct elf_dyn_relocs **) vpp;
+ 		  }
+ 
+ 		p = *head;
+ 		if (p == NULL || p->sec != sec)
+ 		  {
+ 		    size_t amt = sizeof *p;
+-		    p = ((struct elf64_mb_dyn_relocs *)
++		    p = ((struct elf_dyn_relocs *)
+ 			 bfd_alloc (htab->elf.dynobj, amt));
+ 		    if (p == NULL)
+ 		      return false;
+@@ -2913,8 +2893,8 @@ microblaze_elf_copy_indirect_symbol (struct bfd_link_info *info,
+     {
+       if (edir->dyn_relocs != NULL)
+ 	{
+-	  struct elf64_mb_dyn_relocs **pp;
+-	  struct elf64_mb_dyn_relocs *p;
++	  struct elf_dyn_relocs **pp;
++	  struct elf_dyn_relocs *p;
+ 
+ 	  if (ind->root.type == bfd_link_hash_indirect)
+ 	    abort ();
+@@ -2923,7 +2903,7 @@ microblaze_elf_copy_indirect_symbol (struct bfd_link_info *info,
+ 	     list.  Merge any entries against the same section.  */
+ 	  for (pp = &eind->dyn_relocs; (p = *pp) != NULL; )
+ 	    {
+-	      struct elf64_mb_dyn_relocs *q;
++	      struct elf_dyn_relocs *q;
+ 
+ 	      for (q = edir->dyn_relocs; q != NULL; q = q->next)
+ 		if (q->sec == p->sec)
+@@ -2954,7 +2934,7 @@ microblaze_elf_adjust_dynamic_symbol (struct bfd_link_info *info,
+ {
+   struct elf64_mb_link_hash_table *htab;
+   struct elf64_mb_link_hash_entry * eh;
+-  struct elf64_mb_dyn_relocs *p;
++  struct elf_dyn_relocs *p;
+   asection *sdynbss;
+   asection *s, *srel;
+   unsigned int power_of_two;
+@@ -3098,7 +3078,7 @@ allocate_dynrelocs (struct elf_link_hash_entry *h, void * dat)
+   struct bfd_link_info *info;
+   struct elf64_mb_link_hash_table *htab;
+   struct elf64_mb_link_hash_entry *eh;
+-  struct elf64_mb_dyn_relocs *p;
++  struct elf_dyn_relocs *p;
+ 
+   if (h->root.type == bfd_link_hash_indirect)
+     return true;
+@@ -3231,7 +3211,7 @@ allocate_dynrelocs (struct elf_link_hash_entry *h, void * dat)
+ 	  && (h->forced_local
+ 	      || info->symbolic))
+ 	{
+-	  struct elf64_mb_dyn_relocs **pp;
++	  struct elf_dyn_relocs **pp;
+ 
+ 	  for (pp = &eh->dyn_relocs; (p = *pp) != NULL; )
+ 	    {
+@@ -3325,7 +3305,7 @@ microblaze_elf_size_dynamic_sections (bfd *output_bfd ATTRIBUTE_UNUSED,
+ 	{
+ 	  struct elf_dyn_relocs *p;
+ 
+-	  for (p = ((struct elf64_mb_dyn_relocs *)
++	  for (p = ((struct elf_dyn_relocs *)
+ 		    elf_section_data (s)->local_dynrel);
+ 	       p != NULL;
+ 	       p = p->next)
+-- 
+2.47.2
+

--- a/meta-microblaze/recipes-devtools/binutils/binutils/0059-microblaze-Correct-missing-return-type-in-function-s.patch
+++ b/meta-microblaze/recipes-devtools/binutils/binutils/0059-microblaze-Correct-missing-return-type-in-function-s.patch
@@ -1,0 +1,50 @@
+From a3bd5336213685c4806cc2ac11080aee0a12bc6f Mon Sep 17 00:00:00 2001
+From: Graeme Smecher <gsmecher@t0.technology>
+Date: Wed, 16 Jul 2025 10:22:54 -0700
+Subject: [PATCH 59/61] microblaze: Correct missing return type in function
+ signature
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes the following build error on gcc-14:
+
+    gcc [...] -c ../../opcodes/microblaze-dis.c -o microblaze-dis.o
+    ../../opcodes/microblaze-dis.c:146:1: error: return type defaults to ‘int’ [-Wimplicit-int]
+      146 | get_field_imm16 (struct string_buf *buf, long instr)
+          | ^~~~~~~~~~~~~~~
+    ../../opcodes/microblaze-dis.c:146:1: warning: no previous prototype for ‘get_field_imm16’ [-Wmissing-prototypes]
+    ../../opcodes/microblaze-dis.c: In function ‘get_field_imm16’:
+    ../../opcodes/microblaze-dis.c:151:10: error: returning ‘char *’ from a function with return type ‘int’ makes integer from pointer without a cast [-Wint-conversion]
+      151 |   return p;
+          |          ^
+    ../../opcodes/microblaze-dis.c: In function ‘print_insn_microblaze’:
+    ../../opcodes/microblaze-dis.c:481:39: warning: format ‘%s’ expects argument of type ‘char *’, but argument 4 has type ‘int’ [-Wformat=]
+      481 |           print_func (stream, "\t%s, %s",
+          |                                      ~^
+          |                                       |
+          |                                       char *
+          |                                      %d
+      482 |                   get_field_rd (&buf, inst), get_field_imm16 (&buf, inst));
+          |                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          |                                              |
+          |                                              int
+---
+ opcodes/microblaze-dis.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/opcodes/microblaze-dis.c b/opcodes/microblaze-dis.c
+index 912fa31b..5db26a93 100644
+--- a/opcodes/microblaze-dis.c
++++ b/opcodes/microblaze-dis.c
+@@ -143,6 +143,7 @@ get_field_imm15 (struct string_buf *buf, long instr)
+   return p;
+ }
+ 
++static char *
+ get_field_imm16 (struct string_buf *buf, long instr)
+ {
+   char *p = strbuf (buf);
+-- 
+2.47.2
+

--- a/meta-microblaze/recipes-devtools/binutils/binutils/0060-microblaze-correct-incompatible-type-cast-gcc-14.patch
+++ b/meta-microblaze/recipes-devtools/binutils/binutils/0060-microblaze-correct-incompatible-type-cast-gcc-14.patch
@@ -1,0 +1,35 @@
+From 678bd8666befa5e0c3a0e32a52466bc7c893295a Mon Sep 17 00:00:00 2001
+From: Graeme Smecher <gsmecher@t0.technology>
+Date: Wed, 16 Jul 2025 10:26:05 -0700
+Subject: [PATCH 60/61] microblaze: correct incompatible type cast (gcc-14)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The old cast is incorrect, and no cast is actually necessary.
+Fixes the following build error with gcc-14:
+
+    ../../gas/config/tc-microblaze.c: In function ‘md_begin’:
+    ../../gas/config/tc-microblaze.c:413:15: error: assignment to ‘struct op_code_struct *’ from incompatible pointer type ‘struct microblaze_opcodes *’ [-Wincompatible-pointer-types]
+      413 |   for (opcode = (struct microblaze_opcodes *)microblaze_opcodes; opcode->name; opcode ++)
+          |               ^
+---
+ gas/config/tc-microblaze.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gas/config/tc-microblaze.c b/gas/config/tc-microblaze.c
+index 3c0a4688..35e8bc5b 100644
+--- a/gas/config/tc-microblaze.c
++++ b/gas/config/tc-microblaze.c
+@@ -410,7 +410,7 @@ md_begin (void)
+   opcode_hash_control = str_htab_create ();
+ 
+   /* Insert unique names into hash table.  */
+-  for (opcode = (struct microblaze_opcodes *)microblaze_opcodes; opcode->name; opcode ++)
++  for (opcode = microblaze_opcodes; opcode->name; opcode ++)
+     {
+       if (strcmp (prev_name, opcode->name))
+ 	{
+-- 
+2.47.2
+

--- a/meta-microblaze/recipes-devtools/binutils/binutils/0061-RFC-work-around-compiler-errors-that-certainly-deser.patch
+++ b/meta-microblaze/recipes-devtools/binutils/binutils/0061-RFC-work-around-compiler-errors-that-certainly-deser.patch
@@ -1,0 +1,113 @@
+From 0ed46583abf93ec9e54936acfa0b5f52b69621e8 Mon Sep 17 00:00:00 2001
+From: Graeme Smecher <gsmecher@t0.technology>
+Date: Wed, 16 Jul 2025 18:28:42 +0000
+Subject: [PATCH 61/61] RFC: work around compiler errors that certainly deserve
+ a closer look
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This commit is NOT the final word on the matter. With gcc-14, I get the
+following compiler errors:
+
+    gcc  -DHAVE_CONFIG_H -I. -I../../gas  -I. -I../../gas -I../bfd -I../../gas/config -I../../gas/../include -I../../gas/.. -I../../gas/../bfd -DLOCALEDIR="\"/home/gsmecher/crs/crs-yocto/build/tmp-t0-crs-microblaze-pmu/work/x86_64-linux/binutils-cross-microblazeel/2.42/recipe-sysroot-native/usr/share/locale\"" -isystem/home/gsmecher/crs/crs-yocto/build/tmp-t0-crs-microblaze-pmu/work/x86_64-linux/binutils-cross-microblazeel/2.42/recipe-sysroot-native/usr/include -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -Wstack-usage=262144 -Wwrite-strings -I../../gas/../zlib  -isystem/home/gsmecher/crs/crs-yocto/build/tmp-t0-crs-microblaze-pmu/work/x86_64-linux/binutils-cross-microblazeel/2.42/recipe-sysroot-native/usr/include -O2 -pipe     -c -o config/tc-microblaze.o ../../gas/config/tc-microblaze.c
+    chmod u+w doc/asconfig.texi
+    In file included from ../../gas/config/tc-microblaze.c:27:
+    ../../gas/config/tc-microblaze.c: In function ‘md_assemble’:
+    ../../gas/../opcodes/microblaze-opc.h:95:27: warning: overflow in conversion from ‘unsigned int’ to ‘short int’ changes value from ‘4227858432’ to ‘0’ [-Woverflow]
+       95 | #define OPCODE_MASK_H     0xFC000000 /* High 6 bits only.  */
+          |                           ^~~~~~~~~~
+    ../../gas/config/tc-microblaze.c:1053:38: note: in expansion of macro ‘OPCODE_MASK_H’
+     1053 |           opcode->inst_offset_type = OPCODE_MASK_H;
+          |                                      ^~~~~~~~~~~~~
+    ../../gas/../opcodes/microblaze-opc.h:96:26: warning: overflow in conversion from ‘unsigned int’ to ‘short int’ changes value from ‘4229890048’ to ‘0’ [-Woverflow]
+       96 | #define OPCODE_MASK_LIMM 0xFC1F0000 /* High 6 bits and 12-16 bits */
+          |                          ^~~~~~~~~~
+    ../../gas/config/tc-microblaze.c:1082:38: note: in expansion of macro ‘OPCODE_MASK_LIMM’
+     1082 |           opcode->inst_offset_type = OPCODE_MASK_LIMM;
+          |                                      ^~~~~~~~~~~~~~~~
+    ../../gas/config/tc-microblaze.c:1549:41: error: passing argument 2 of ‘parse_reg’ from incompatible pointer type [-Wincompatible-pointer-types]
+     1549 |         op_end = parse_reg (op_end + 1, &immed);  /* Get rfslN.  */
+          |                                         ^~~~~~
+          |                                         |
+          |                                         long long unsigned int *
+    ../../gas/config/tc-microblaze.c:440:33: note: expected ‘unsigned int *’ but argument is of type ‘long long unsigned int *’
+      440 | parse_reg (char * s, unsigned * reg)
+          |                      ~~~~~~~~~~~^~~
+    ../../gas/config/tc-microblaze.c:1692:41: error: passing argument 2 of ‘parse_reg’ from incompatible pointer type [-Wincompatible-pointer-types]
+     1692 |         op_end = parse_reg (op_end + 1, &immed);  /* Get rfslN.  */
+          |                                         ^~~~~~
+          |                                         |
+          |                                         long long unsigned int *
+    ../../gas/config/tc-microblaze.c:440:33: note: expected ‘unsigned int *’ but argument is of type ‘long long unsigned int *’
+      440 | parse_reg (char * s, unsigned * reg)
+          |                      ~~~~~~~~~~~^~~
+    ../../gas/config/tc-microblaze.c:1710:41: error: passing argument 2 of ‘parse_reg’ from incompatible pointer type [-Wincompatible-pointer-types]
+     1710 |         op_end = parse_reg (op_end + 1, &immed);  /* Get rfslN.  */
+          |                                         ^~~~~~
+          |                                         |
+          |                                         long long unsigned int *
+    ../../gas/config/tc-microblaze.c:440:33: note: expected ‘unsigned int *’ but argument is of type ‘long long unsigned int *’
+      440 | parse_reg (char * s, unsigned * reg)
+          |                      ~~~~~~~~~~~^~~
+
+This patch avoids the errors and maintains what I believe to be the
+current behaviour. However, there is certainly something wrong here -
+the code should be verified against design intent, and these workarounds
+should be discarded.
+---
+ gas/config/tc-microblaze.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/gas/config/tc-microblaze.c b/gas/config/tc-microblaze.c
+index 35e8bc5b..f9d6a303 100644
+--- a/gas/config/tc-microblaze.c
++++ b/gas/config/tc-microblaze.c
+@@ -1050,7 +1050,7 @@ md_assemble (char * str)
+ 	{
+           
+  	  opcode->inst_type=INST_TYPE_RD_R1_IMML;
+-          opcode->inst_offset_type = OPCODE_MASK_H;
++          opcode->inst_offset_type = 0; /* FIXME OPCODE_MASK_H; */
+           if (streq (name, "addli"))
+  	    opcode->bit_sequence = ADDLI_MASK;
+           else if (streq (name, "addlic"))
+@@ -1079,7 +1079,7 @@ md_assemble (char * str)
+       else
+         {
+ 	  opcode->inst_type=INST_TYPE_RD_IMML;
+-          opcode->inst_offset_type = OPCODE_MASK_LIMM;
++          opcode->inst_offset_type = 0; /* FIXME OPCODE_MASK_LIMM; */
+           if (streq (name, "addli"))
+  	    opcode->bit_sequence = ADDLI_ONE_REG_MASK;
+           else if (streq (name, "addlic"))
+@@ -1546,7 +1546,7 @@ md_assemble (char * str)
+           reg1 = 0;
+         }
+       if (strcmp (op_end, ""))
+-        op_end = parse_reg (op_end + 1, &immed);  /* Get rfslN.  */
++        op_end = parse_reg (op_end + 1, (unsigned *)&immed);  /* Get rfslN.  */
+       else
+ 	{
+           as_fatal (_("Error in statement syntax"));
+@@ -1689,7 +1689,7 @@ md_assemble (char * str)
+           reg1 = 0;
+         }
+       if (strcmp (op_end, ""))
+-        op_end = parse_reg (op_end + 1, &immed);  /* Get rfslN.  */
++        op_end = parse_reg (op_end + 1, (unsigned *)&immed);  /* Get rfslN.  */
+       else
+ 	{
+           as_fatal (_("Error in statement syntax"));
+@@ -1707,7 +1707,7 @@ md_assemble (char * str)
+ 
+     case INST_TYPE_RFSL:
+       if (strcmp (op_end, ""))
+-        op_end = parse_reg (op_end + 1, &immed);  /* Get rfslN.  */
++        op_end = parse_reg (op_end + 1, (unsigned *)&immed);  /* Get rfslN.  */
+       else
+ 	{
+           as_fatal (_("Error in statement syntax"));
+-- 
+2.47.2
+


### PR DESCRIPTION
The binutils patches carried in meta-xilinx/meta-microblaze/recipes-devtools/binutils do not build when using gcc-14. This patch series contains two kinds of things:

1. Workarounds for compiler errors that seem reasonable, and
2. A couple of workarounds for compiler errors that look more serious

Item (1) needs review, but item (2) needs some care and attention. This PR is not meant to be merged wholesale.

The patches themselves contain build error messages in fairly excruciating detail.