### PR TITLE
arm-trusted-firmware-a: fix do_install / do_deploy across bitbake runs

### DIFF
--- a/meta-xilinx-core/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.10.0-xilinx-v2024.2.bb
+++ b/meta-xilinx-core/recipes-bsp/trusted-firmware-a/trusted-firmware-a_2.10.0-xilinx-v2024.2.bb
@@ -119,14 +119,16 @@ inherit deploy
 DEPENDS += "u-boot-mkimage-native"
 
 do_deploy() {
-    # Copy the /boot items to deploy
+    # Copy the /boot items to deploy. This may be a different bitbake run than
+    # do_install(), so ATF_BASE_NAME may have changed - use the symlinks
+    # instead of the underlying files.
     install -d ${DEPLOYDIR}
-    install -m 0644 ${D}/boot/${ATF_BASE_NAME}.elf ${DEPLOYDIR}/${ATF_BASE_NAME}.elf
+    install -m 0644 ${D}/boot/arm-trusted-firmware.elf ${DEPLOYDIR}/${ATF_BASE_NAME}.elf
     ln -sf ${ATF_BASE_NAME}.elf ${DEPLOYDIR}/arm-trusted-firmware.elf
-    install -m 0644 ${D}/boot/${ATF_BASE_NAME}.bin ${DEPLOYDIR}/${ATF_BASE_NAME}.bin
+    install -m 0644 ${D}/boot/arm-trusted-firmware.bin ${DEPLOYDIR}/${ATF_BASE_NAME}.bin
     ln -sf ${ATF_BASE_NAME}.bin ${DEPLOYDIR}/arm-trusted-firmware.bin
 
-    install -m 0644 ${D}/boot/${ATF_BASE_NAME}.ub ${DEPLOYDIR}/${ATF_BASE_NAME}.ub
+    install -m 0644 ${D}/boot/arm-trusted-firmware.ub ${DEPLOYDIR}/${ATF_BASE_NAME}.ub
     ln -sf ${ATF_BASE_NAME}.ub ${DEPLOYDIR}/arm-trusted-firmware.ub
     ln -sf ${ATF_BASE_NAME}.ub ${DEPLOYDIR}/atf-uboot.ub
 }


### PR DESCRIPTION
Currently, do_install() copies files into ${D}/boot and do_deploy() copies them from there into ${DEPLOYDIR}. However, when do_install() and do_deploy() are executed across different bitbake runs, ${IMAGE_VERSION_SUFFIX} changes and the ${ATF_BASE_NAME} used for filenames differs between the two. This causes failures during do_deploy():

    | DEBUG: Executing shell function do_deploy
    | install: cannot stat '[...]/build/tmp/work/t0_crs-poky-linux/trusted-firmware-a/2.10.0-xilinx-v2024.2/image/boot/arm-trusted-firmware--2.10.0-xilinx-v2024.2-r0-20250724184305.elf': No such file or directory
    | WARNING: [...]/build/tmp/work/t0_crs-poky-linux/trusted-firmware-a/2.10.0-xilinx-v2024.2/temp/run.do_deploy.1652316:143 exit 1 from 'install -m 0644 [...]/build/tmp/work/t0_crs-poky-linux/trusted-firmware-a/2.10.0-xilinx-v2024.2/image/boot/arm-trusted-firmware--2.10.0-xilinx-v2024.2-r0-20250724184305.elf [...]/build/tmp/work/t0_crs-poky-linux/trusted-firmware-a/2.10.0-xilinx-v2024.2/deploy-trusted-firmware-a/arm-trusted-firmware--2.10.0-xilinx-v2024.2-r0-20250724184305.elf'
    | WARNING: Backtrace (BB generated script):
    | 	#1: do_deploy, [...]/build/tmp/work/t0_crs-poky-linux/trusted-firmware-a/2.10.0-xilinx-v2024.2/temp/run.do_deploy.1652316, line 143
    | 	#2: main, [...]/build/tmp/work/t0_crs-poky-linux/trusted-firmware-a/2.10.0-xilinx-v2024.2/temp/run.do_deploy.1652316, line 154

This patch uses fixed filenames for the deployment process.