### PR TITLE
Fix rproc1/rpu1 (R5 Cluster 1) missing on openamp zynqmp domain file

### DIFF
--- a/meta-xilinx-standalone-sdt/conf/domainyaml/openamp-overlay-zynqmp.yaml
+++ b/meta-xilinx-standalone-sdt/conf/domainyaml/openamp-overlay-zynqmp.yaml
@@ -5,6 +5,12 @@ definitions:
                flags: 0
              - dev: psu_r5_0_btcm_global@ffe20000
                flags: 0
+          
+         openamp_channel1_access_srams: &openamp_channel1_access_srams # used for access in each domain
+             - dev: psu_r5_1_atcm_global@ffe90000
+               flags: 0
+             - dev: psu_r5_1_btcm_global@ffeb0000
+               flags: 0
 
          rproc0: &rproc0
              - start: 0x9800000
@@ -23,6 +29,26 @@ definitions:
 
          rpu0vdev0buffer: &rpu0vdev0buffer
              - start: 0x9868000
+               size: 0x40000
+               no-map: 1
+
+         rproc1: &rproc1
+             - start: 0x9e00000
+               size: 0x60000
+               no-map: 1
+
+         rpu1vdev0vring0: &rpu1vdev0vring0
+             - start: 0x9e60000
+               size: 0x4000
+               no-map: 1
+
+         rpu1vdev0vring1: &rpu1vdev0vring1
+             - start: 0x9e64000
+               size: 0x4000
+               no-map: 1
+
+         rpu1vdev0buffer: &rpu1vdev0buffer
+             - start: 0x9e68000
                size: 0x40000
                no-map: 1
 
@@ -45,6 +71,12 @@ domains:
               flags: {}
             - dev: ipi1
               flags: {}
+            - dev: cpus_r5_1
+              flags: {}
+            - dev: ipi7
+              flags: {}
+            - dev: ipi2
+              flags: {}
             - dev: "/cpus-a53@0/cpu@0"
               label: psu_cortexa53_0
               flags: {}
@@ -57,6 +89,10 @@ domains:
             - dev: psu_r5_0_atcm_global@ffe00000
               flags: {}
             - dev: psu_r5_0_btcm_global@ffe20000
+              flags: {}
+            - dev: psu_r5_1_atcm_global@ffe90000
+              flags: {}
+            - dev: psu_r5_1_btcm_global@ffeb0000
               flags: {}
             - dev: amba_pl
             - dev: gem0
@@ -72,7 +108,7 @@ domains:
 
         reserved-memory:
             ranges: true
-            <<+: [ *rpu0vdev0vring1, *rpu0vdev0vring0, *rpu0vdev0buffer, *rproc0 ]
+            <<+: [ *rpu0vdev0vring1, *rpu0vdev0vring0, *rpu0vdev0buffer, *rproc0, *rpu1vdev0vring1, *rpu1vdev0vring0, *rpu1vdev0buffer, *rproc1]
 
         domain-to-domain:
             compatible: openamp,domain-to-domain-v1
@@ -80,8 +116,10 @@ domains:
                 compatible: openamp,remoteproc-v2
                 remote:
                     - openamp_r5_0_cluster
+                    - openamp_r5_1_cluster
                 elfload:
                     - [ psu_r5_0_atcm_global@ffe00000, psu_r5_0_btcm_global@ffe20000, rproc0 ]
+                    - [ psu_r5_1_atcm_global@ffe90000, psu_r5_1_btcm_global@ffeb0000, rproc1 ]
 
             rpmsg-relation:
                 compatible: openamp,rpmsg-v1
@@ -91,6 +129,9 @@ domains:
                      - rpu0vdev0vring0
                      - rpu0vdev0vring1
                      - rpu0vdev0buffer
+                     - rpu1vdev0vring0
+                     - rpu1vdev0vring1
+                     - rpu1vdev0buffer
                 mbox:
                     - ipi7
 
@@ -138,5 +179,50 @@ domains:
                      - rpu0vdev0vring0
                      - rpu0vdev0vring1
                      - rpu0vdev0buffer
+    
+    openamp_r5_1_cluster:
+        compatible:
+            - "openamp,domain-v1"
+        cpus:
+            - cluster: cpus_r5_1
+              cpumask: 0x2
+              mode:
+              secure: true
+              cluster_cpu: psu_cortexr5_1
+        os,type: freertos
+        access:
+            - dev: psu_r5_1_atcm_global@ffe90000
+              label: psu_r5_1_atcm_global
+              flags: {}
+            - dev: psu_r5_1_btcm_global@ffeb0000
+              flags: {}
+              label: psu_r5_1_btcm_global
+            - dev: ipi7
+              flags: {}
+            - dev: ipi2
+              flags: {}
+            - dev: memory@100000
+              flags: {}
+            - dev: psu_rpu
+              flags: {}
+            - dev: ttc3
+              flags: {}
+
+        reserved-memory:
+            ranges: true
+            <<+: [ *rpu1vdev0vring1, *rpu1vdev0vring0, *rpu1vdev0buffer, *rproc1 ]
+
+        domain-to-domain:
+             compatible: openamp,domain-to-domain-v1
+             rpmsg-relation:
+                 compatible: openamp,rpmsg-v1
+                 host:
+                     - openamp_a53_0_cluster
+                 mbox:
+                     - ipi2
+                 carveouts:
+                     - rpu1vdev0vring0
+                     - rpu1vdev0vring1
+                     - rpu1vdev0buffer
 
 


### PR DESCRIPTION
Hi Xilinx/AMD developer,

In Vivado 2025.1, the OpenAMP domain file for the Zynq UltraScale+ was located in the [meta-openamp](https://github.com/Xilinx/meta-openamp/blob/xlnx-rel-v2025.1/vendor/xilinx/meta-xilinx-standalone-sdt/recipes-openamp/open-amp/overlays/openamp-overlay-zynqmp.yaml) layer. This document appears to have been removed in the following [commit](https://github.com/Xilinx/meta-openamp/commit/cc7a54969c887823a934c705edd9825f3fad672e).

Starting from Vivado 2025.2, the domain file was moved to the [meta-xilinx](https://github.com/Xilinx/meta-xilinx/blob/xlnx-rel-v2025.2/meta-xilinx-standalone-sdt/conf/domainyaml/openamp-overlay-zynqmp.yaml) layer. 

However, I noticed that the updated file no longer includes the definition for RPU1.
Is there a specific reason why RPU1 support was removed?

I have added back the RPU1 configuration and tested the modified domain file.
Everything appears to be working correctly in my environment.

Both R5 cores are visible in dmesg:
<img width="1125" height="288" alt="image" src="https://github.com/user-attachments/assets/a3a53133-4f15-45a1-91b2-b7e709a281bf" />

`remoteproc0` and `remoteproc1` both start successfully:
<img width="1834" height="157" alt="image" src="https://github.com/user-attachments/assets/cc28d5bf-387b-4a67-8b56-a075925e9e07" />

Could you please review my implementation and confirm whether it is correct?
Additionally, is it valid for both RPU cores to access TTC3 concurrently, or should each core be assigned its own TTC instance?

Thanks for your time, and I appreciate any guidance.