### PR TITLE
Fix/wic: Fix TypeError in bootimg-partition by adding sector_size argument

### DIFF
--- a/meta-xilinx-core/scripts/lib/wic/plugins/source/bootimg-partition.py
+++ b/meta-xilinx-core/scripts/lib/wic/plugins/source/bootimg-partition.py
@@ -166,7 +166,7 @@ class BootimgPartitionPlugin(SourcePlugin):
     @classmethod
     def do_prepare_partition(cls, part, source_params, cr, cr_workdir,
                              oe_builddir, bootimg_dir, kernel_dir,
-                             rootfs_dir, native_sysroot):
+                             rootfs_dir, native_sysroot, sector_size):
         """
         Called to do the actual content population for a partition i.e. it
         'prepares' the partition to be incorporated into the image.


### PR DESCRIPTION
### Description
This PR resolves a build failure during the do_image_wic task. The error is caused by a signature mismatch in the bootimg-partition source plugin.

### The Issue
When using recent versions of the Yocto Project (Poky), the Wic engine's partition.py calls the plugin's do_prepare_partition method with an additional sector_size keyword argument. Because the meta-xilinx-core local copy of this plugin does not include this parameter in its method definition, the build fails with:

```
TypeError: BootimgPartitionPlugin.do_prepare_partition() got an unexpected keyword argument 'sector_size'
```

### The Fix
Updated the do_prepare_partition method signature in scripts/lib/wic/plugins/source/bootimg-partition.py to accept the sector_size argument. This ensures compatibility with the upstream Wic engine API.

### Testing Performed
Environment: Yocto Project (Poky) with meta-xilinx.

Build Target: petalinux-image-minimal (or your specific machine, e.g., xczu2eg).

Result: do_image_wic completes successfully, and the resulting .wic image is generated without errors.