### PR TITLE
fetch shared source code before patching because meta-user may want to patch shared source code

### DIFF
--- a/meta-xilinx-standalone/classes/xlnx-embeddedsw.bbclass
+++ b/meta-xilinx-standalone/classes/xlnx-embeddedsw.bbclass
@@ -63,7 +63,7 @@ python do_copy_shared_src() {
 
 python() {
     if d.getVar('BPN') != "embeddedsw-source":
-        bb.build.addtask('do_copy_shared_src', 'do_configure do_populate_lic do_deploy_source_date_epoch', 'do_patch', d)
+        bb.build.addtask('do_copy_shared_src', 'do_patch do_configure do_populate_lic do_deploy_source_date_epoch', 'do_unpack', d)
 
         d.appendVarFlag('do_copy_shared_src', 'depends', ' embeddedsw-source-${PV}:do_patch')
 }


### PR DESCRIPTION
When patching a recipe that inherits xlnx-embeddedsw, patches applied via a .bbappend fail because do_patch runs before do_copy_shared_src, leaving the source directory empty at patch time.

This fix changes the task ordering so do_copy_shared_src runs after do_unpack but before do_patch, ensuring the shared source is present when patches are applied.

Tested on Petalinux 2025.1 targeting the Ultra96v2 (ZU3EG) with a pmu-firmware_%.bbappend that applies custom patches to the shared embeddedsw source.